### PR TITLE
Updated the captcha config to use .env keys. Defaults to test keys.

### DIFF
--- a/config/captcha.php
+++ b/config/captcha.php
@@ -25,10 +25,11 @@ return [
     /*
      |------------------------------------------------------------------------------------------------
      |  Credentials
+     |
+     |  Grab captcha keys from .env file. Default uses default test keys.
      | ------------------------------------------------------------------------------------------------
      */
 
-    'secretkey' => '',
-    'sitekey' => '',
-
+    'secretkey' => env('CAPTCHA_SECRETKEY', '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'),
+    'sitekey' => env('CAPTCHA_SITEKEY', '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'),
 ];


### PR DESCRIPTION
config/captcha.php is out of sync with git when you add keys directly to the file. Updated to use the .env file. The default also uses the test keys provided by google if no site keys are configured.

```
env('CAPTCHA_SECRETKEY')
env('CAPTCHA_SITEKEY')
```

![Captcha Logo](https://developers.google.com/recaptcha/images/recaptcha_test.png)

[https://developers.google.com/recaptcha/docs/faq](url)