### PR TITLE
Update VersionCheck Component

### DIFF
--- a/app/Http/Controllers/Staff/VersionController.php
+++ b/app/Http/Controllers/Staff/VersionController.php
@@ -34,6 +34,9 @@ class VersionController extends Controller
         $client = new Client();
         $response = json_decode($client->get('https://api.github.com/repos/HDInnovations/UNIT3D/releases')->getBody());
         $lastestVersion = $response[0]->tag_name;
-        return response(['updated' => version_compare($this->version, $lastestVersion, '<') ? 'true' : 'false']);
+        return response([
+            'updated' => version_compare($this->version, $lastestVersion, '<') ? 'false' : 'true',
+            'latestversion' => $lastestVersion
+        ]);
     }
 }

--- a/resources/assets/js/components/Version.vue
+++ b/resources/assets/js/components/Version.vue
@@ -7,45 +7,56 @@
 </template>
 
 <script>
-  import Swal from 'sweetalert2'
+import Swal from "sweetalert2";
 
-  export default {
+export default {
+  data() {
+    return {
+      loading: false
+    };
+  },
 
-    data() {
-      return {
-        loading: false,
-      }
-    },
-
-    methods: {
-      checkUpdate() {
-        this.loading = true;
-        axios.get('/staff_dashboard/check-update')
-          .then((response) => {
-            if (response.data.updated === false) {
-              this.loading = false;
-              Swal({
-                position: 'center',
-                type: 'warning',
-                title: 'There Is A Update Available!',
-                showConfirmButton: false,
-                timer: 4500
-              })
-            } else {
-              this.loading = false;
-              Swal({
-                position: 'center',
-                type: 'success',
-                title: 'You Are Running The Latest Version Of UNIT3D!',
-                showConfirmButton: false,
-                timer: 4500
-              })
-            }
-          })
-          .catch((error) => {
-            Swal('Oops...', error.response.data, 'error')
-          })
-      },
+  methods: {
+    checkUpdate() {
+      this.loading = true;
+      axios
+        .get("/staff_dashboard/check-update")
+        .then(response => {
+          if (response.data.updated === "false") {
+            this.loading = false;
+            Swal({
+              position: "center",
+              type: "warning",
+              title: "There Is A Update Available!",
+              showCancelButton: true,
+              showConfirmButton: true,
+              confirmButtonText:
+                '<i class="fa fa-github"></i> Download from Github',
+              html: `New version <a href="//github.com/HDInnovations/UNIT3D/releases">v${
+                response.data.latestversion
+              } </a> is available`
+            }).then(result => {
+              if (result.value) {
+                window.location.assign(
+                  "//github.com/HDInnovations/UNIT3D/releases"
+                );
+              }
+            });
+          } else {
+            this.loading = false;
+            Swal({
+              position: "center",
+              type: "success",
+              title: "You Are Running The Latest Version Of UNIT3D!",
+              showCancelButton: false,
+              timer: 4500
+            });
+          }
+        })
+        .catch(error => {
+          Swal("Oops...", error.response.data, "error");
+        });
     }
   }
+};
 </script>


### PR DESCRIPTION
Updated the version check component.

* Version.vue [Line 25] - was checking for a boolean but a string is returned from VersionController.
* VersionController.php [Line 37] - was returning “true” if the current installed version was less then latest version. The version component was only showing “**There Is A Update Available**” if the return data was false. This was not triggered if the current version is less then the available version. 
`check_version("v1.6", "v1.7", "<") ? "true" : "false"` returns `{"updated":"true"}`
* Updated the sweetalert2 popup to have a link to download the latest version

<img width="308" alt="screen shot 2018-04-27 at 11 36 45 pm" src="https://user-images.githubusercontent.com/61000/39392963-15ffba0a-4a74-11e8-8e6c-cb6a2253c0d5.png">
