### PR TITLE
Remove extra "v" prefix from version number #269

### DIFF
--- a/resources/assets/js/components/Version.vue
+++ b/resources/assets/js/components/Version.vue
@@ -32,7 +32,7 @@ export default {
               showConfirmButton: true,
               confirmButtonText:
                 '<i class="fa fa-github"></i> Download from Github',
-              html: `New version <a href="//github.com/HDInnovations/UNIT3D/releases">v${
+              html: `New version <a href="//github.com/HDInnovations/UNIT3D/releases">${
                 response.data.latestversion
               } </a> is available`
             }).then(result => {


### PR DESCRIPTION
Not sure if I missed it or the Tag name was updated. Removed extra "v" in version link

<img width="314" alt="screen shot 2018-04-28 at 8 28 09 am" src="https://user-images.githubusercontent.com/61000/39398125-2509a78c-4abe-11e8-926a-1f2f48a8d9a8.png">
