### PR TITLE
Torrent filter by uploader returns 404 error

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -412,7 +412,7 @@ class TorrentController extends Controller
 
         if ($request->has('uploader') && $request->input('uploader') != null) {
             $match = User::where('username', 'like', $uploader)->first();
-            if(null === $match){
+            if (null === $match){
                 return ['result'=>[],'count'=>0];
             }
             $torrent->where('user_id', $match->id)->where('anon', 0);

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -411,7 +411,10 @@ class TorrentController extends Controller
         }
 
         if ($request->has('uploader') && $request->input('uploader') != null) {
-            $match = User::where('username', 'like', $uploader)->firstOrFail();
+            $match = User::where('username', 'like', $uploader)->first();
+            if(null === $match){
+                return ['result'=>[],'count'=>0];
+            }
             $torrent->where('user_id', $match->id)->where('anon', 0);
         }
 


### PR DESCRIPTION
## Problem
When doing a filter for torrents by a uploader (if not found), it returns:
`Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException` when firstOrFail() dies. This returns a 404 error

Because of the 404 return in the Ajax call, the spinner never stops and it looks like a search is still running.

<img width="726" alt="screen shot 2018-04-28 at 3 13 16 pm" src="https://user-images.githubusercontent.com/61000/39401709-a2b74fa8-4b00-11e8-8d49-97da8de5fc47.png">

## Possible Solution
Return a empty result array (to replace the spinner) and a count of 0 if the uploader is not found.