### PR TITLE
(fix) renders missing array elements in search result

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -661,8 +661,11 @@ class TorrentController extends Controller
 
             $hungry = array_chunk($prelauncher, $qty);
             $fed = [];
-            if (is_array($hungry) && array_key_exists($page-1, $hungry)) {
-                $fed = $hungry[$page-1];
+			if ($page == 0){
+				$page = 1;
+			}            
+            if (is_array($hungry) && array_key_exists($page - 1, $hungry)) {
+                $fed = $hungry[$page - 1];
             }
             $totals = [];
             $counts = [];
@@ -725,8 +728,11 @@ class TorrentController extends Controller
 
             $hungry = array_chunk($prelauncher, $qty);
             $fed = [];
-            if (is_array($hungry) && array_key_exists($page-1, $hungry)) {
-                $fed = $hungry[$page-1];
+			if ($page == 0){
+				$page = 1;
+			}              
+            if (is_array($hungry) && array_key_exists($page - 1, $hungry)) {
+                $fed = $hungry[$page - 1];
             }
             $torrents = Torrent::with(['user', 'category'])->withCount(['thanks', 'comments'])->whereIn('id', $fed)->orderBy($sorting, $order)->get();
         } else {


### PR DESCRIPTION
Occurs when Null/0 $page value is posted back and is used for array index. Hence, not compatible with "-1" commit # 903c148391ddba75393bfb8ef0133bc871ee552d