### PR TITLE
Slow torrent list

### DIFF
--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -78,7 +78,7 @@ class TorrentController extends Controller
         $user = $request->user();
         $repository = $this->faceted;
 
-        $torrents = Torrent::with(['user', 'category', 'tags'])->withCount(['thanks', 'comments'])->orderBy('sticky', 'desc')->orderBy('created_at', 'desc')->paginate(50);
+        $torrents = Torrent::with(['user', 'category', 'tags'])->withCount(['thanks', 'comments'])->orderBy('sticky', 'desc')->orderBy('created_at', 'desc')->paginate(25);
         $personal_freeleech = PersonalFreeleech::where('user_id', '=', $user->id)->first();
         $bookmarks = Bookmark::where('user_id', $user->id)->get();
 
@@ -535,7 +535,7 @@ class TorrentController extends Controller
             if (! $history || ! is_array($history)) {
                 $history = [];
             }
-            $torrent = $torrent->with(['user', 'category'])->withCount(['thanks', 'comments'])->whereNotIn('torrents.id', $history);
+            $torrent = $torrent->with(['user', 'category', 'tags'])->withCount(['thanks', 'comments'])->whereNotIn('torrents.id', $history);
         } elseif ($history == 1) {
             $torrent = History::where('history.user_id', '=', $user->id);
             $torrent->where(function ($query) use ($user, $seedling, $downloaded, $leeching, $idling) {
@@ -564,7 +564,7 @@ class TorrentController extends Controller
                 $join->on('history.info_hash', '=', 'torrents.info_hash');
             })->groupBy('torrents.id');
         } else {
-            $torrent = $torrent->with(['user', 'category'])->withCount(['thanks', 'comments']);
+            $torrent = $torrent->with(['user', 'category', 'tags'])->withCount(['thanks', 'comments']);
         }
         if ($collection != 1) {
             if ($request->has('search') && $request->input('search') != null) {
@@ -683,7 +683,7 @@ class TorrentController extends Controller
             }
             $totals = [];
             $counts = [];
-            $launcher = Torrent::with(['user', 'category'])->withCount(['thanks', 'comments'])->whereIn('imdb', $fed)->orderBy($sorting, $order);
+            $launcher = Torrent::with(['user', 'category', 'tags'])->withCount(['thanks', 'comments'])->whereIn('imdb', $fed)->orderBy($sorting, $order);
             foreach ($launcher->cursor() as $chunk) {
                 if ($chunk->imdb) {
                     if (! array_key_exists($chunk->imdb, $totals)) {
@@ -748,7 +748,7 @@ class TorrentController extends Controller
             if (is_array($hungry) && array_key_exists($page - 1, $hungry)) {
                 $fed = $hungry[$page - 1];
             }
-            $torrents = Torrent::with(['user', 'category'])->withCount(['thanks', 'comments'])->whereIn('id', $fed)->orderBy($sorting, $order)->get();
+            $torrents = Torrent::with(['user', 'category', 'tags'])->withCount(['thanks', 'comments'])->whereIn('id', $fed)->orderBy($sorting, $order)->get();
         } else {
             $torrents = $torrent->orderBy('sticky', 'desc')->orderBy($sorting, $order)->paginate($qty);
         }

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -13,7 +13,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Bookmark;
 use Carbon\Carbon;
 use App\Models\Peer;
 use App\Models\Type;
@@ -22,6 +21,7 @@ use App\Models\History;
 use App\Models\Torrent;
 use App\Models\Warning;
 use App\Helpers\Bencode;
+use App\Models\Bookmark;
 use App\Models\Category;
 use App\Helpers\MediaInfo;
 use App\Models\TagTorrent;

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -13,6 +13,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Bookmark;
 use Carbon\Carbon;
 use App\Models\Peer;
 use App\Models\Type;
@@ -75,13 +76,16 @@ class TorrentController extends Controller
     public function torrents(Request $request)
     {
         $user = $request->user();
-        $personal_freeleech = PersonalFreeleech::where('user_id', '=', $user->id)->first();
-        $torrents = Torrent::with(['user', 'category'])->withCount(['thanks', 'comments'])->orderBy('sticky', 'desc')->orderBy('created_at', 'desc')->paginate(25);
         $repository = $this->faceted;
+
+        $torrents = Torrent::with(['user', 'category', 'tags'])->withCount(['thanks', 'comments'])->orderBy('sticky', 'desc')->orderBy('created_at', 'desc')->paginate(50);
+        $personal_freeleech = PersonalFreeleech::where('user_id', '=', $user->id)->first();
+        $bookmarks = Bookmark::where('user_id', $user->id)->get();
 
         return view('torrent.torrents', [
             'personal_freeleech' => $personal_freeleech,
             'repository'         => $repository,
+            'bookmarks'          => $bookmarks,
             'torrents'           => $torrents,
             'user'               => $user,
             'sorting'            => '',
@@ -299,6 +303,8 @@ class TorrentController extends Controller
             }
         }
 
+        $bookmarks = Bookmark::where('user_id', $user->id)->get();
+
         return view('torrent.groupings', [
             'torrents'           => $torrents,
             'user'               => $user,
@@ -309,6 +315,7 @@ class TorrentController extends Controller
             'personal_freeleech' => $personal_freeleech,
             'repository'         => $repository,
             'attributes'         => $attributes,
+            'bookmarks'          => $bookmarks,
         ])->render();
     }
 
@@ -798,6 +805,8 @@ class TorrentController extends Controller
             $logger = 'torrent.results';
         }
 
+        $bookmarks = Bookmark::where('user_id', $user->id)->get();
+
         return view($logger, [
             'torrents'           => $torrents,
             'user'               => $user,
@@ -808,6 +817,7 @@ class TorrentController extends Controller
             'totals'             => $totals,
             'repository'         => $repository,
             'attributes'         => $attributes,
+            'bookmarks'          => $bookmarks,
         ])->render();
     }
 

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -202,7 +202,7 @@ class Torrent extends Model
      */
     public function tags()
     {
-        return $this->belongsToMany(Tag::class);
+        return $this->belongsToMany(Tag::class, 'tag_torrent', 'torrent_id', 'tag_name', 'id', 'name');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -680,6 +680,16 @@ class User extends Authenticatable
     }
 
     /**
+     * Has many free leech tokens.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function freeleechTokens()
+    {
+        return $this->hasMany(FreeleechToken::class);
+    }
+
+    /**
      * Get the Users username as slug.
      *
      * @return string

--- a/app/Services/Clients/Client.php
+++ b/app/Services/Clients/Client.php
@@ -13,14 +13,11 @@
 
 namespace App\Services\Clients;
 
-use Predis\Client as RedisClient;
 use GuzzleHttp\Client as GuzzleClient;
 
 abstract class Client
 {
     protected $guzzle;
-
-    protected $redis;
 
     protected $apiUrl;
 
@@ -30,7 +27,6 @@ abstract class Client
 
     public function __construct($apiUrl, $apiKey = null)
     {
-        $this->redis = new RedisClient();
         $this->apiUrl = ($this->apiSecure ? 'https://' : 'http://').$apiUrl;
         $this->apiKey = $apiKey;
         $this->guzzle = new GuzzleClient();

--- a/app/Services/Clients/Client.php
+++ b/app/Services/Clients/Client.php
@@ -71,13 +71,13 @@ abstract class Client
         $key = 'movietvdb:'.$key;
 
         if ($data) {
-            $this->redis->setex($key, 604800, serialize($data));
-
-            return $data;
+            cache()->remember($key, 7 * 24 * 60, function () use ($data) {
+                return serialize($data);
+            });
         }
 
-        if ($cache = $this->redis->get($key)) {
-            return unserialize($cache);
+        if (cache()->has($key)) {
+            return unserialize(cache()->get($key));
         }
 
         return $data;

--- a/resources/views/torrent/groupings.blade.php
+++ b/resources/views/torrent/groupings.blade.php
@@ -354,7 +354,7 @@
                                                                                     </a>
                                                                                 @endif
 
-                                                                                <span id="torrentBookmark{{ $current->id }}" torrent="{{ $current->id }}" state="{{ $current->bookmarked() ? 1 : 0}}" class="torrentBookmark"></span>
+                                                                                <span id="torrentBookmark{{ $current->id }}" torrent="{{ $current->id }}" state="{{ $bookmarks->where('torrent_id', $current->id)->first() ? 1 : 0}}" class="torrentBookmark"></span>
 
                                                                                 <br>
                                                                                 @if ($current->anon == 1)
@@ -419,8 +419,7 @@
                             </span>
                                                                                 @endif
 
-                                                                                @php $freeleech_token = \App\Models\FreeleechToken::where('user_id', '=', $user->id)->where('torrent_id', '=', $current->id)->first(); @endphp
-                                                                                @if ($freeleech_token)
+                                                                                @if ($user->freeleechTokens->where('torrent_id', $current->id)->first())
                                                                                     <span class='badge-extra text-bold'>
                                 <i class='{{ config("other.font-awesome") }} fa-star text-bold' data-toggle='tooltip' title=''
                                    data-original-title='@lang('torrent.freeleech-token')'></i> @lang('torrent.freeleech-token')

--- a/resources/views/torrent/results.blade.php
+++ b/resources/views/torrent/results.blade.php
@@ -103,32 +103,31 @@
                             </a>
                         @endif
 
-                        <span data-toggle="tooltip" data-original-title="Bookmark" id="torrentBookmark{{ $torrent->id }}" torrent="{{ $torrent->id }}" state="{{ $torrent->bookmarked() ? 1 : 0}}" class="torrentBookmark"></span>
+                        <span data-toggle="tooltip" data-original-title="Bookmark" id="torrentBookmark{{ $torrent->id }}" torrent="{{ $torrent->id }}" state="{{ $bookmarks->where('torrent_id', $torrent->id)->first() ? 1 : 0 }}" class="torrentBookmark"></span>
 
-                        @php $history = \App\Models\History::where('user_id', '=', $user->id)->where('info_hash', '=', $torrent->info_hash)->first(); @endphp
-                        @if ($history)
-                            @if ($history->seeder == 1 && $history->active == 1)
+                        @if ($current = $user->history->where('info_hash', $torrent->info_hash)->first())
+                            @if ($current->seeder == 1 && $current->active == 1)
                                 <button class="btn btn-success btn-circle" type="button" data-toggle="tooltip"
                                         data-original-title="@lang('torrent.currently-seeding')!">
                                     <i class="{{ config('other.font-awesome') }} fa-arrow-up"></i>
                                 </button>
                             @endif
 
-                            @if ($history->seeder == 0 && $history->active == 1)
+                            @if ($current->seeder == 0 && $current->active == 1)
                                 <button class="btn btn-warning btn-circle" type="button" data-toggle="tooltip"
                                         data-original-title="@lang('torrent.currently-leeching')!">
                                     <i class="{{ config('other.font-awesome') }} fa-arrow-down"></i>
                                 </button>
                             @endif
 
-                            @if ($history->seeder == 0 && $history->active == 0 && $history->completed_at == null)
+                            @if ($current->seeder == 0 && $current->active == 0 && $current->completed_at == null)
                                 <button class="btn btn-info btn-circle" type="button" data-toggle="tooltip"
                                         data-original-title="@lang('torrent.not-completed')!">
                                     <i class="{{ config('other.font-awesome') }} fa-spinner"></i>
                                 </button>
                             @endif
 
-                            @if ($history->seeder == 0 && $history->active == 0 && $history->completed_at != null)
+                            @if ($current->seeder == 0 && $current->active == 0 && $current->completed_at != null)
                                 <button class="btn btn-danger btn-circle" type="button" data-toggle="tooltip"
                                         data-original-title="@lang('torrent.completed-not-seeding')!">
                                     <i class="{{ config('other.font-awesome') }} fa-thumbs-down"></i>
@@ -231,8 +230,7 @@
                             </span>
                         @endif
 
-                        @php $freeleech_token = \App\Models\FreeleechToken::where('user_id', '=', $user->id)->where('torrent_id', '=', $torrent->id)->first(); @endphp
-                        @if ($freeleech_token)
+                        @if ($user->freeleechTokens->where('torrent_id', $torrent->id)->first())
                             <span class='badge-extra text-bold'>
                                 <i class='{{ config("other.font-awesome") }} fa-star text-bold' data-toggle='tooltip' title=''
                                     data-original-title='@lang('torrent.freeleech-token')'></i> @lang('torrent.freeleech-token')
@@ -302,15 +300,12 @@
                             </span>
                         @endif
 
-                        @php $torrent_tags = App\Models\TagTorrent::where('torrent_id', '=', $torrent->id)->get(); @endphp
-                        @if ($torrent_tags)
-                        @foreach($torrent_tags as $torrent_tag)
+                        @foreach($torrent->tags as $tag)
                             <span class="badge-extra text-bold">
                                 <i class='{{ config("other.font-awesome") }} fa-tag' data-toggle='tooltip' title=''
-                                   data-original-title='@lang('torrent.genre')'></i> {{ $torrent_tag->genre->name }}
+                                   data-original-title='@lang('torrent.genre')'></i> {{ $tag->name }}
                             </span>
                         @endforeach
-                        @endif
                     </td>
 
                     <td>

--- a/resources/views/torrent/results_groupings.blade.php
+++ b/resources/views/torrent/results_groupings.blade.php
@@ -133,7 +133,7 @@
                                                             </a>
                                                         @endif
 
-                                                        <span data-toggle="tooltip" data-original-title="Bookmark" id="torrentBookmark{{ $current->id }}" torrent="{{ $current->id }}" state="{{ $current->bookmarked() ? 1 : 0}}" class="torrentBookmark"></span>
+                                                        <span data-toggle="tooltip" data-original-title="Bookmark" id="torrentBookmark{{ $current->id }}" torrent="{{ $current->id }}" state="{{ $bookmarks->where('torrent_id', $current->id)->first() ? 1 : 0}}" class="torrentBookmark"></span>
 
                                                         <br>
                                                         @if ($current->anon == 1)


### PR DESCRIPTION
The torrents index page is actually slow to load and uses a lot of server resources, when loading the page, normally it runs around 100~ queries to generate the page, and another 100~ queries for every time you use the search bar (with 25 pagination).

If you double the pagination the amount of queries also double!

After this PR the page takes around 20~ queries to load the page. And this amount doesn't change if you increase the pagination.

I decided to leave the pagination the same as I was unsure if you wanted to increase this limit or not?

The same logic used to speed up the home page is used here.

Furthermore, I updated the movie database client to cache the data using any cache driver that laravel supports. Before you were forced to use redis, which I don't have on my local machine. (I can revert this if needed)