### PR TITLE
(Fix) overlapping warning bar 🐛

### DIFF
--- a/resources/views/user/profile.blade.php
+++ b/resources/views/user/profile.blade.php
@@ -384,7 +384,7 @@
 
                     <div class="progress">
                         <div class="progress-bar progress-bar-danger progress-bar-striped active" role="progressbar"
-                             style="width:.1%; border-bottom-color: rgb(140,4,8);">
+                             style="width:0%; border-bottom-color: rgb(140,4,8);">
                         </div>
                         @php $percent = 100 / config('hitrun.max_warnings'); @endphp
                         @foreach ($warnings as $warning)


### PR DESCRIPTION
I'm not sure if we even need that first (extra?) div... But this should fix the over- flowing/lapping warning bar when there's three active warnings.