### PR TITLE
(Fix) Remove htmlspecialchars from comment quote function

### DIFF
--- a/resources/views/components/forum/post.blade.php
+++ b/resources/views/components/forum/post.blade.php
@@ -110,16 +110,7 @@
                             document.getElementById('forum_reply_form').style.display = 'block';
                             input = document.getElementById('bbcode-content');
                             input.value += '[quote={{ \htmlspecialchars('@' . $post->user->username) }}]';
-                            input.value += (() => {
-                                var text = document.createElement('textarea');
-                                text.innerHTML = decodeURIComponent(
-                                    atob($refs.content.dataset.base64Bbcode)
-                                        .split('')
-                                        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-                                        .join('')
-                                );
-                                return text.value;
-                            })();
+                            input.value += decodeURIComponent(escape(atob('{{ base64_encode($post->content) }}')));
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -28,11 +28,8 @@
                             input = document.getElementById(
                                 '{{ $comment->isParent() ? 'new-comment__textarea' : 'reply-comment' }}'
                             );
-                            input.value +=
-                                '[quote={{ \htmlspecialchars($comment->anon ? 'Anonymous' : '@' . $comment->user->username) }}]';
-                            input.value += decodeURIComponent(
-                                escape(atob('{{ base64_encode(\htmlspecialchars($comment->content)) }}'))
-                            );
+                            input.value += '[quote={{ $comment->anon ? 'Anonymous' : '@' . $comment->user->username }}]';
+                            input.value += decodeURIComponent(escape(atob('{{ base64_encode($comment->content) }}')));
                             input.value += '[/quote]';
                             input.dispatchEvent(new Event('input'));
                             input.focus();

--- a/resources/views/torrent/partials/description.blade.php
+++ b/resources/views/torrent/partials/description.blade.php
@@ -24,7 +24,9 @@
             Alpine.data('description', () => ({
                 copy() {
                     text = document.createElement('textarea');
-                    text.innerHTML = decodeURIComponent(escape(atob('{{ base64_encode($torrent->description) }}')));
+                    text.innerHTML = decodeURIComponent(
+                        escape(atob('{{ base64_encode($torrent->description) }}')),
+                    );
                     navigator.clipboard.writeText(text.value);
                     Swal.fire({
                         toast: true,

--- a/resources/views/torrent/partials/description.blade.php
+++ b/resources/views/torrent/partials/description.blade.php
@@ -24,12 +24,7 @@
             Alpine.data('description', () => ({
                 copy() {
                     text = document.createElement('textarea');
-                    text.innerHTML = decodeURIComponent(
-                        atob('{{ base64_encode($torrent->description) }}')
-                            .split('')
-                            .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-                            .join(''),
-                    );
+                    text.innerHTML = decodeURIComponent(escape(atob('{{ base64_encode($torrent->description) }}')));
                     navigator.clipboard.writeText(text.value);
                     Swal.fire({
                         toast: true,


### PR DESCRIPTION
When replying to a message that has any special characters like quotes or ampersands it would html encode them in plain text, this removes that operation to make it work properly.