### PR TITLE
(Fix) Extend donation expiry instead of keeping the old expiry

### DIFF
--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -72,9 +72,19 @@ class DonationController extends Controller
         $donation = Donation::with(['user', 'package'])->findOrFail($id);
         $donation->status = Donation::APPROVED;
         $donation->starts_at = $now;
+        $active_donation = Donation::where('status', '=', Donation::APPROVED)->where('user_id', '=', $donation->user->id)->latest()->first();
 
         if ($donation->package->donor_value > 0) {
-            $donation->ends_at = $now->addDays($donation->package->donor_value);
+            if ($donation->user->is_lifetime) {
+                $donation->ends_at = null;
+            } else {
+                if (!is_null($active_donation->ends_at) && $donation->user->is_donor) {
+                    $active_donation_expiry = Carbon::parse($active_donation->ends_at);
+                    $donation->ends_at = $active_donation_expiry->addDays($donation->package->donor_value);
+                } else {
+                    $donation->ends_at = $now->addDays($donation->package->donor_value);
+                }
+            }
         } else {
             $donation->ends_at = null;
         }


### PR DESCRIPTION
If a user donates a second time before their first donation expires, their donation expiry doesn't get extended but remains as their longest donation date. What this aims to do is make the second donation have the expiry of their old donation (that hasn't expired) with the additional days of their newest donation. 

TODO: find last donation that isn't expired