### PR TITLE
(Add) Staff Comments on Reports

### DIFF
--- a/app/Http/Livewire/Comment.php
+++ b/app/Http/Livewire/Comment.php
@@ -31,6 +31,7 @@ use App\Achievements\UserMadeTenComments;
 use App\Models\Article;
 use App\Models\Collection;
 use App\Models\Playlist;
+use App\Models\Report;
 use App\Models\Ticket;
 use App\Models\Torrent;
 use App\Models\TorrentRequest;
@@ -48,7 +49,7 @@ class Comment extends Component
 
     protected ChatRepository $chatRepository;
 
-    public null|Article|Collection|Playlist|Ticket|Torrent|TorrentRequest $model;
+    public null|Article|Collection|Playlist|Report|Ticket|Torrent|TorrentRequest $model;
 
     public \App\Models\Comment $comment;
 
@@ -131,7 +132,7 @@ class Comment extends Component
 
     final public function postReply(): void
     {
-        abort_unless($this->model instanceof Ticket || (auth()->user()->can_comment ?? auth()->user()->group->can_comment), 403, __('comment.rights-revoked'));
+        abort_unless($this->model instanceof Ticket || $this->model instanceof Report || (auth()->user()->can_comment ?? auth()->user()->group->can_comment), 403, __('comment.rights-revoked'));
 
         abort_if($this->model instanceof Torrent && $this->model->status !== Torrent::APPROVED, 403, __('comment.torrent-status'));
 
@@ -183,7 +184,7 @@ class Comment extends Component
         $users = User::whereIn('username', $this->taggedUsers())->get();
         Notification::sendNow($users, new NewCommentTag($this->model, $reply));
 
-        if (!$this->model instanceof Ticket) {
+        if (!$this->model instanceof Ticket && !$this->model instanceof Report) {
             // Auto Shout
             $username = $reply->anon ? 'An anonymous user' : '[url='.href_profile($this->user).']'.$this->user->username.'[/url]';
 

--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -142,7 +142,6 @@ class Comments extends Component
                 break;
             case $this->model instanceof Article:
             case $this->model instanceof Playlist:
-            case $this->model instanceof Report:
             case $this->model instanceof TorrentRequest:
             case $this->model instanceof Torrent:
                 if ($this->user->id !== $this->model->user_id) {

--- a/app/Http/Livewire/Comments.php
+++ b/app/Http/Livewire/Comments.php
@@ -31,6 +31,7 @@ use App\Achievements\UserMadeTenComments;
 use App\Models\Article;
 use App\Models\Collection;
 use App\Models\Playlist;
+use App\Models\Report;
 use App\Models\Ticket;
 use App\Models\Torrent;
 use App\Models\TorrentRequest;
@@ -55,7 +56,7 @@ class Comments extends Component
 
     public ?User $user;
 
-    public null|Article|Collection|Playlist|Ticket|Torrent|TorrentRequest $model;
+    public null|Article|Collection|Playlist|Report|Ticket|Torrent|TorrentRequest $model;
 
     public bool $anon = false;
 
@@ -112,7 +113,7 @@ class Comments extends Component
     final public function postComment(): void
     {
         // Authorization
-        abort_unless($this->model instanceof Ticket || ($this->user->can_comment ?? $this->user->group->can_comment), 403, __('comment.rights-revoked'));
+        abort_unless($this->model instanceof Ticket || $this->model instanceof Report || ($this->user->can_comment ?? $this->user->group->can_comment), 403, __('comment.rights-revoked'));
 
         abort_if($this->model instanceof Torrent && $this->model->status !== Torrent::APPROVED, 403, __('comment.torrent-status'));
 
@@ -141,6 +142,7 @@ class Comments extends Component
                 break;
             case $this->model instanceof Article:
             case $this->model instanceof Playlist:
+            case $this->model instanceof Report:
             case $this->model instanceof TorrentRequest:
             case $this->model instanceof Torrent:
                 if ($this->user->id !== $this->model->user_id) {
@@ -154,7 +156,7 @@ class Comments extends Component
         $users = User::whereIn('username', $this->taggedUsers())->get();
         Notification::sendNow($users, new NewCommentTag($this->model, $comment));
 
-        if (!$this->model instanceof Ticket) {
+        if (!$this->model instanceof Ticket && !$this->model instanceof Report) {
             // Auto Shout
             $username = $comment->anon ? 'An anonymous user' : '[url='.href_profile($this->user).']'.$this->user->username.'[/url]';
 

--- a/app/Http/Livewire/ReportSearch.php
+++ b/app/Http/Livewire/ReportSearch.php
@@ -74,6 +74,7 @@ class ReportSearch extends Component
     final public function reports(): \Illuminate\Pagination\LengthAwarePaginator
     {
         return Report::orderBy('solved')
+            ->withCount(['comments'])
             ->with('reported.group', 'reporter.group', 'staff.group')
             ->when($this->type !== null, fn ($query) => $query->where('type', '=', $this->type))
             ->when($this->reporter !== null, fn ($query) => $query->whereIn('reporter_id', User::withTrashed()->select('id')->where('username', 'LIKE', '%'.$this->reporter.'%')))

--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -122,4 +122,12 @@ class Report extends Model
             'id'       => User::SYSTEM_USER_ID,
         ]);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany<Comment, $this>
+     */
+    public function comments(): \Illuminate\Database\Eloquent\Relations\MorphMany
+    {
+        return $this->morphMany(Comment::class, 'commentable');
+    }
 }

--- a/app/Notifications/NewCommentTag.php
+++ b/app/Notifications/NewCommentTag.php
@@ -20,6 +20,7 @@ use App\Models\Article;
 use App\Models\Collection;
 use App\Models\Comment;
 use App\Models\Playlist;
+use App\Models\Report;
 use App\Models\Ticket;
 use App\Models\Torrent;
 use App\Models\TorrentRequest;
@@ -34,7 +35,7 @@ class NewCommentTag extends Notification implements ShouldQueue
     /**
      * NewCommentTag Constructor.
      */
-    public function __construct(public Torrent|TorrentRequest|Ticket|Playlist|Collection|Article $model, public Comment $comment)
+    public function __construct(public Torrent|TorrentRequest|Ticket|Playlist|Report|Collection|Article $model, public Comment $comment)
     {
     }
 
@@ -73,6 +74,11 @@ class NewCommentTag extends Notification implements ShouldQueue
                 'title' => $title,
                 'body'  => $username.' has tagged you in an comment on Ticket '.$this->model->subject,
                 'url'   => '/tickets/'.$this->model->id,
+            ],
+            $this->model instanceof Report => [
+                'title' => $title,
+                'body'  => $username.' has tagged you in an comment on Report '.$this->model->title,
+                'url'   => '/dashboard/reports/'.$this->model->id,
             ],
             $this->model instanceof Playlist => [
                 'title' => $title,

--- a/app/Notifications/NewCommentTag.php
+++ b/app/Notifications/NewCommentTag.php
@@ -62,37 +62,37 @@ class NewCommentTag extends Notification implements ShouldQueue
         return match (true) {
             $this->model instanceof Torrent => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Torrent '.$this->model->name,
+                'body'  => $username.' has tagged you in a comment on Torrent '.$this->model->name,
                 'url'   => '/torrents/'.$this->model->id,
             ],
             $this->model instanceof TorrentRequest => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Torrent Request '.$this->model->name,
+                'body'  => $username.' has tagged you in a comment on Torrent Request '.$this->model->name,
                 'url'   => '/requests/'.$this->model->id,
             ],
             $this->model instanceof Ticket => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Ticket '.$this->model->subject,
+                'body'  => $username.' has tagged you in a comment on Ticket '.$this->model->subject,
                 'url'   => '/tickets/'.$this->model->id,
             ],
             $this->model instanceof Report => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Report '.$this->model->title,
+                'body'  => $username.' has tagged you in a comment on Report '.$this->model->title,
                 'url'   => '/dashboard/reports/'.$this->model->id,
             ],
             $this->model instanceof Playlist => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Playlist '.$this->model->name,
+                'body'  => $username.' has tagged you in a comment on Playlist '.$this->model->name,
                 'url'   => '/playlists/'.$this->model->id,
             ],
             $this->model instanceof Collection => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Collection '.$this->model->name,
+                'body'  => $username.' has tagged you in a comment on Collection '.$this->model->name,
                 'url'   => '/mediahub/collections/'.$this->model->id,
             ],
             $this->model instanceof Article => [
                 'title' => $title,
-                'body'  => $username.' has tagged you in an comment on Article '.$this->model->title,
+                'body'  => $username.' has tagged you in a comment on Article '.$this->model->title,
                 'url'   => '/articles/'.$this->model->id,
             ],
         };

--- a/resources/views/Staff/report/show.blade.php
+++ b/resources/views/Staff/report/show.blade.php
@@ -19,9 +19,7 @@
             {{ __('staff.reports-log') }}
         </a>
     </li>
-    <li class="breadcrumb--active">
-        {{ __('common.report') }} Details
-    </li>
+    <li class="breadcrumb--active">{{ __('common.report') }} Details</li>
 @endsection
 
 @section('page', 'page__poll--show')
@@ -101,7 +99,6 @@
 @endsection
 
 @section('sidebar')
-
     <section class="panelV2">
         <h2 class="panel__heading">Reported {{ __('common.user') }}</h2>
         <div class="panel__body">

--- a/resources/views/Staff/report/show.blade.php
+++ b/resources/views/Staff/report/show.blade.php
@@ -19,7 +19,9 @@
             {{ __('staff.reports-log') }}
         </a>
     </li>
-    <li class="breadcrumb--active">{{ __('common.report') }} Details</li>
+    <li class="breadcrumb--active">
+        {{ __('common.report') }} Details
+    </li>
 @endsection
 
 @section('page', 'page__poll--show')
@@ -68,6 +70,8 @@
         </section>
     @endif
 
+    <livewire:comments :model="$report" />
+
     @if ($report->solved)
         <section class="panelV2">
             <h2 class="panel__heading">Verdict</h2>
@@ -97,6 +101,7 @@
 @endsection
 
 @section('sidebar')
+
     <section class="panelV2">
         <h2 class="panel__heading">Reported {{ __('common.user') }}</h2>
         <div class="panel__body">
@@ -122,6 +127,7 @@
             @endif
         </div>
     </section>
+
     <section class="panelV2">
         <h2 class="panel__heading">Snooze</h2>
         @if ($report->snoozed_until !== null)

--- a/resources/views/livewire/report-search.blade.php
+++ b/resources/views/livewire/report-search.blade.php
@@ -163,9 +163,7 @@
                             @include('livewire.includes._sort-icon', ['field' => 'reporter_id'])
                         </th>
                         <th>
-                            <i
-                                class="{{ config('other.font-awesome') }} fa-comment-alt-lines"
-                            ></i>
+                            <i class="{{ config('other.font-awesome') }} fa-comment-alt-lines"></i>
                         </th>
                         <th wire:click="sortBy('created_at')" role="columnheader button">
                             {{ __('user.created-on') }}

--- a/resources/views/livewire/report-search.blade.php
+++ b/resources/views/livewire/report-search.blade.php
@@ -162,6 +162,11 @@
                             {{ __('common.reporter') }}
                             @include('livewire.includes._sort-icon', ['field' => 'reporter_id'])
                         </th>
+                        <th>
+                            <i
+                                class="{{ config('other.font-awesome') }} fa-comment-alt-lines"
+                            ></i>
+                        </th>
                         <th wire:click="sortBy('created_at')" role="columnheader button">
                             {{ __('user.created-on') }}
                             @include('livewire.includes._sort-icon', ['field' => 'created_at'])
@@ -191,6 +196,9 @@
                             </td>
                             <td>
                                 <x-user_tag :anon="false" :user="$report->reporter" />
+                            </td>
+                            <td>
+                                {{ $report->comments_count }}
                             </td>
                             <td>
                                 <time

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -28,19 +28,17 @@ use Illuminate\Support\Facades\Broadcast;
  * |
  */
 
-Broadcast::channel('chatroom.{id}', function ($user, $id) {
-    return User::select([
-        'id',
-        'username',
-        'group_id',
-        'image',
-        'chatroom_id',
-        'chat_status_id',
-        'is_lifetime',
-        'is_donor',
-        'icon'
-    ])
-        ->with(['chatStatus:id,color', 'chatroom:id,name', 'group:id,color,effect,icon'])
-        ->find($user->id);
-});
+Broadcast::channel('chatroom.{id}', fn ($user, $id) => User::select([
+    'id',
+    'username',
+    'group_id',
+    'image',
+    'chatroom_id',
+    'chat_status_id',
+    'is_lifetime',
+    'is_donor',
+    'icon'
+])
+    ->with(['chatStatus:id,color', 'chatroom:id,name', 'group:id,color,effect,icon'])
+    ->find($user->id));
 Broadcast::channel('chatter.{id}', fn ($user, $id) => $user->id == $id);


### PR DESCRIPTION
Add the comments widget to reports, giving staff the ability to converse about a particular report before determining a verdict.