### PR TITLE
(Add) Shadow underneath secondary nav

### DIFF
--- a/resources/sass/themes/_cosmic-void.scss
+++ b/resources/sass/themes/_cosmic-void.scss
@@ -242,7 +242,7 @@
     --scrollbar-color: #ffffff13;
 
     --secondary-nav-bg: #292929;
-    --secondary-nav-box-shadow: none;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     --secondary-nav-tab-fg: #aaa;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #777 2px;

--- a/resources/sass/themes/_galactic.scss
+++ b/resources/sass/themes/_galactic.scss
@@ -281,7 +281,7 @@
     --scrollbar-color: #ffffff19;
 
     --secondary-nav-bg: #292929;
-    --secondary-nav-box-shadow: none;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     --secondary-nav-tab-fg: #aaa;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #777 2px;

--- a/resources/sass/themes/_light.scss
+++ b/resources/sass/themes/_light.scss
@@ -253,7 +253,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #e2e2e2;
-    --secondary-nav-box-shadow: none;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     --secondary-nav-tab-fg: #222;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #222 2px;

--- a/resources/sass/themes/_material-design-v3-dark.scss
+++ b/resources/sass/themes/_material-design-v3-dark.scss
@@ -253,7 +253,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #221e24;
-    --secondary-nav-box-shadow: none;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     --secondary-nav-tab-fg: #999;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #0099ff 2px;

--- a/resources/sass/themes/_material-design-v3-light.scss
+++ b/resources/sass/themes/_material-design-v3-light.scss
@@ -252,7 +252,7 @@
     --scrollbar-color: #0004;
 
     --secondary-nav-bg: #f4f4f4;
-    --secondary-nav-box-shadow: none;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     --secondary-nav-tab-fg: #050505;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: underline #0099ff 2px;

--- a/resources/sass/themes/_nord.scss
+++ b/resources/sass/themes/_nord.scss
@@ -268,7 +268,7 @@
     --scrollbar-color: #ffffff19;
 
     --secondary-nav-bg: #242933;
-    --secondary-nav-box-shadow: none;
+    --secondary-nav-box-shadow: 0 8px 10px 0 rgba(0, 0, 0, 0.2);
     --secondary-nav-tab-fg: #d8dee9;
     --secondary-nav-tab-bg: inherit;
     --secondary-nav-tab-active-text-decoration: transparent #81a1c1 2px;


### PR DESCRIPTION
Instead of only underneath the top nav which is almost always covered by the secondary nav.