### PR TITLE
(Add) Age ratings to TV and movie metadata

### DIFF
--- a/app/Models/TmdbMovie.php
+++ b/app/Models/TmdbMovie.php
@@ -30,6 +30,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string                          $title_sort
  * @property string|null                     $original_language
  * @property int|null                        $adult
+ * @property string|null                     $certification
+ * @property array|null                      $content_ratings
  * @property string|null                     $backdrop
  * @property string|null                     $budget
  * @property string|null                     $homepage
@@ -58,12 +60,13 @@ class TmdbMovie extends Model
     /**
      * Get the attributes that should be cast.
      *
-     * @return array{release_date: 'datetime'}
+     * @return array{release_date: 'datetime', content_ratings: 'array'}
      */
     protected function casts(): array
     {
         return [
             'release_date' => 'datetime',
+            'content_ratings' => 'array',
         ];
     }
 

--- a/app/Models/TmdbMovie.php
+++ b/app/Models/TmdbMovie.php
@@ -65,7 +65,7 @@ class TmdbMovie extends Model
     protected function casts(): array
     {
         return [
-            'release_date' => 'datetime',
+            'release_date'    => 'datetime',
             'content_ratings' => 'array',
         ];
     }

--- a/app/Models/TmdbMovie.php
+++ b/app/Models/TmdbMovie.php
@@ -31,7 +31,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null                     $original_language
  * @property int|null                        $adult
  * @property string|null                     $certification
- * @property array|null                      $content_ratings
+ * @property array<string, mixed>|null       $content_ratings
  * @property string|null                     $backdrop
  * @property string|null                     $budget
  * @property string|null                     $homepage

--- a/app/Models/TmdbTv.php
+++ b/app/Models/TmdbTv.php
@@ -53,6 +53,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property string|null                     $trailer
+ * @property int|null                        $adult
+ * @property string|null                     $certification
+ * @property array|null                      $content_ratings
  */
 class TmdbTv extends Model
 {
@@ -68,13 +71,14 @@ class TmdbTv extends Model
     /**
      * Get the attributes that should be cast.
      *
-     * @return array{first_air_date: 'datetime', last_air_date: 'datetime'}
+     * @return array{first_air_date: 'datetime', last_air_date: 'datetime', content_ratings: 'array'}
      */
     protected function casts(): array
     {
         return [
             'first_air_date' => 'datetime',
             'last_air_date'  => 'datetime',
+            'content_ratings' => 'array',
         ];
     }
 

--- a/app/Models/TmdbTv.php
+++ b/app/Models/TmdbTv.php
@@ -53,9 +53,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property string|null                     $trailer
- * @property int|null                        $adult
  * @property string|null                     $certification
- * @property array|null                      $content_ratings
  */
 class TmdbTv extends Model
 {
@@ -76,8 +74,8 @@ class TmdbTv extends Model
     protected function casts(): array
     {
         return [
-            'first_air_date' => 'datetime',
-            'last_air_date'  => 'datetime',
+            'first_air_date'  => 'datetime',
+            'last_air_date'   => 'datetime',
             'content_ratings' => 'array',
         ];
     }

--- a/app/Services/Tmdb/Client/Movie.php
+++ b/app/Services/Tmdb/Client/Movie.php
@@ -305,10 +305,11 @@ class Movie
 
             if (isset($this->data['release_dates']['results'])) {
                 foreach ($this->data['release_dates']['results'] as $countryData) {
-                    if (isset($countryData['iso_3166_1']) && isset($countryData['release_dates'])) {
+                    if (isset($countryData['iso_3166_1'], $countryData['release_dates'])) {
                         foreach ($countryData['release_dates'] as $releaseDate) {
                             if (!empty($releaseDate['certification'])) {
                                 $contentRatings[$countryData['iso_3166_1']] = $releaseDate['certification'];
+
                                 if ($countryData['iso_3166_1'] === 'US') {
                                     $certification = $releaseDate['certification'];
                                 }

--- a/app/Services/Tmdb/Client/Movie.php
+++ b/app/Services/Tmdb/Client/Movie.php
@@ -229,6 +229,23 @@ class Movie
      *                 type: ?string,
      *             },
      *         >,
+     *     },
+     *     release_dates: ?array{
+     *         id: ?int,
+     *         results: ?array<
+     *             int<0, max>,
+     *             array{
+     *                 iso_3166_1: ?string,
+     *                 release_dates: ?array<
+     *                     int<0, max>,
+     *                     array{
+     *                         certification: ?string,
+     *                         iso_639_1: ?string,
+     *                         release_date: ?string,
+     *                     },
+     *                 >,
+     *             },
+     *         >,
      *     }
      *  }
      */
@@ -246,7 +263,7 @@ class Movie
             ->get('https://api.TheMovieDB.org/3/movie/{id}', [
                 'api_key'            => config('api-keys.tmdb'),
                 'language'           => config('app.meta_locale'),
-                'append_to_response' => 'videos,images,credits,external_ids,keywords,recommendations,alternative_titles',
+                'append_to_response' => 'videos,images,credits,external_ids,keywords,recommendations,alternative_titles,release_dates,content_ratings',
             ])
             ->json();
 
@@ -257,6 +274,8 @@ class Movie
      * @throws Exception
      * @return ?array{
      *     adult: bool,
+     *     certification: ?string,
+     *     content_ratings: array<string, string>,
      *     backdrop: ?string,
      *     budget: ?int,
      *     homepage: ?string,
@@ -281,6 +300,23 @@ class Movie
     {
         if ($this->data !== null && \array_key_exists('title', $this->data) && \is_string($this->data['title'])) {
             $titleSort = null;
+            $certification = null;
+            $contentRatings = [];
+
+            if (isset($this->data['release_dates']['results'])) {
+                foreach ($this->data['release_dates']['results'] as $countryData) {
+                    if (isset($countryData['iso_3166_1']) && isset($countryData['release_dates'])) {
+                        foreach ($countryData['release_dates'] as $releaseDate) {
+                            if (!empty($releaseDate['certification'])) {
+                                $contentRatings[$countryData['iso_3166_1']] = $releaseDate['certification'];
+                                if ($countryData['iso_3166_1'] === 'US') {
+                                    $certification = $releaseDate['certification'];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
             if ($this->data['release_date'] !== null) {
                 $re = '/((?<nameSort>.*)(?<separator>\:|and)(?<remaining>.*)|(?<name>.*))/m';
@@ -297,6 +333,8 @@ class Movie
 
             return [
                 'adult'             => $this->data['adult'] ?? false,
+                'certification'     => $certification,
+                'content_ratings'   => $contentRatings,
                 'backdrop'          => $this->tmdb->image('backdrop', $this->data),
                 'budget'            => $this->data['budget'] ?? null,
                 'homepage'          => $this->data['homepage'] ?? null,

--- a/app/Services/Tmdb/Client/TV.php
+++ b/app/Services/Tmdb/Client/TV.php
@@ -368,8 +368,10 @@ class TV
                 foreach ($this->ratings['results'] as $countryData) {
                     if (!empty($countryData['iso_3166_1']) && !empty($countryData['rating'])) {
                         $contentRatings[$countryData['iso_3166_1']] = $countryData['rating'];
+
                         if ($countryData['iso_3166_1'] === 'US') {
                             $certification = $countryData['rating'];
+
                             break;
                         }
                     }

--- a/app/Services/Tmdb/Client/TV.php
+++ b/app/Services/Tmdb/Client/TV.php
@@ -335,6 +335,7 @@ class TV
 
     /**
      * @return ?array{
+     *     certification: ?string,
      *     backdrop: ?string,
      *     episode_run_time: mixed,
      *     first_air_date: mixed,

--- a/database/migrations/2025_04_21_164330_add_certification_to_tmdb_metadata.php
+++ b/database/migrations/2025_04_21_164330_add_certification_to_tmdb_metadata.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tmdb_movies', function (Blueprint $table): void {
+            $table->string('certification')->nullable()->after('adult');
+            $table->json('content_ratings')->nullable()->after('certification');
+        });
+
+        Schema::table('tmdb_tv', function (Blueprint $table): void {
+            $table->string('certification')->nullable()->after('in_production');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tmdb_movies', function (Blueprint $table): void {
+            $table->dropColumn('certification');
+            $table->dropColumn('content_ratings');
+        });
+
+        Schema::table('tmdb_tv', function (Blueprint $table): void {
+            $table->dropColumn('certification');
+        });
+    }
+}; 

--- a/database/migrations/2025_04_21_164330_add_certification_to_tmdb_metadata.php
+++ b/database/migrations/2025_04_21_164330_add_certification_to_tmdb_metadata.php
@@ -48,4 +48,4 @@ return new class () extends Migration {
             $table->dropColumn('certification');
         });
     }
-}; 
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1852,6 +1852,8 @@ CREATE TABLE `tmdb_movies` (
   `title_sort` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `original_language` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `adult` tinyint(1) DEFAULT NULL,
+  `certification` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content_ratings` json DEFAULT NULL,
   `backdrop` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `budget` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `homepage` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1968,6 +1970,7 @@ CREATE TABLE `tmdb_tv` (
   `status` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `homepage` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `in_production` tinyint(1) DEFAULT NULL,
+  `certification` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `last_air_date` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `next_episode_to_air` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `origin_country` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -2963,3 +2966,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (345,'2025_04_03_08
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (346,'2025_04_07_152108_split_recommendations_into_movie_and_tv',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (347,'2025_04_15_075631_add_description_to_playlist_categories',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (348,'2025_04_15_090705_create_playlist_suggestions',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (349,'2025_04_21_164330_add_certification_to_tmdb_metadata',1);

--- a/resources/views/subtitle/create.blade.php
+++ b/resources/views/subtitle/create.blade.php
@@ -54,7 +54,7 @@
                                 value="{{ $media_language->id }}"
                                 @selected(old('media_language') == $media_language->id)
                             >
-                                {{ $media_language->code }}
+                                {{ $media_language->name }}
                             </option>
                         @endforeach
                     </select>

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -123,6 +123,7 @@
                 </span>
             </li>
         @endif
+
         <li class="work__runtime">
             <span class="work__runtime-text">
                 {{ \Carbon\CarbonInterval::minutes($meta->runtime ?? 0)->cascade()->forHumans(null, true) }}

--- a/resources/views/torrent/partials/movie_meta.blade.php
+++ b/resources/views/torrent/partials/movie_meta.blade.php
@@ -77,19 +77,16 @@
                         </button>
                     </form>
                 </li>
-            @endif
-
-            @if ($meta?->id || $torrent?->tmdb_movie_id ?? null)
                 <li>
                     <form
-                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta?->id ?? $torrent->tmdb_movie_id]) }}"
+                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta->id]) }}"
                         method="post"
                     >
                         @csrf
                         @method('PATCH')
 
                         <button
-                            @if (cache()->has('tmdb-movie-scraper:' . ($meta?->id ?? $torrent->tmdb_movie_id)) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('tmdb-movie-scraper:' . $meta->id) && ! auth()->user()->group->is_modo)
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif
@@ -119,6 +116,13 @@
                 {{ $meta->original_language ?? __('common.unknown') }}
             </a>
         </li>
+        @if ($meta?->certification)
+            <li class="work__certification">
+                <span class="work__certification-text">
+                    {{ $meta->certification }}
+                </span>
+            </li>
+        @endif
         <li class="work__runtime">
             <span class="work__runtime-text">
                 {{ \Carbon\CarbonInterval::minutes($meta->runtime ?? 0)->cascade()->forHumans(null, true) }}

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -122,6 +122,7 @@
                 </span>
             </li>
         @endif
+
         <li class="work__runtime">
             <span class="work__runtime-text">
                 {{ \Carbon\CarbonInterval::minutes($meta->episode_run_time ?? 0)->cascade()->forHumans(null, true) }}

--- a/resources/views/torrent/partials/tv_meta.blade.php
+++ b/resources/views/torrent/partials/tv_meta.blade.php
@@ -77,18 +77,15 @@
                         </button>
                     </form>
                 </li>
-            @endif
-
-            @if ($meta?->id || $torrent?->tmdb_tv_id ?? null)
                 <li>
                     <form
-                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta?->id ?? $torrent->tmdb_tv_id]) }}"
+                        action="{{ route('torrents.similar.update', ['category' => $category, 'metaId' => $meta->id]) }}"
                         method="post"
                     >
                         @csrf
                         @method('PATCH')
                         <button
-                            @if (cache()->has('tmdb-tv-scraper:' . ($meta?->id ?? $torrent->tmdb_tv_id)) && ! auth()->user()->group->is_modo)
+                            @if (cache()->has('tmdb-tv-scraper:' . $meta->id) && ! auth()->user()->group->is_modo)
                                 disabled
                                 title="This item was recently updated. Try again tomorrow."
                             @endif
@@ -118,6 +115,13 @@
                 {{ $meta->original_language ?? __('common.unknown') }}
             </a>
         </li>
+        @if ($meta?->certification)
+            <li class="work__certification">
+                <span class="work__certification-text">
+                    {{ $meta->certification }}
+                </span>
+            </li>
+        @endif
         <li class="work__runtime">
             <span class="work__runtime-text">
                 {{ \Carbon\CarbonInterval::minutes($meta->episode_run_time ?? 0)->cascade()->forHumans(null, true) }}


### PR DESCRIPTION
Age ratings is a significant piece of information on movies and TV shows, these changes adds certification and content ratings to the TMDB table and adds the US age ratings under the title if it's available.