### PR TITLE
(Add) mod queue opt in option to torrent API

### DIFF
--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -417,8 +417,8 @@ class TorrentController extends BaseController
             Keyword::upsert($keywords->toArray(), ['torrent_id', 'name']);
         }
 
-        // check for trusted user and update torrent
-        if ($user->group->is_trusted) {
+        // check for trusted user & mod queue isn't opted in and update torrent
+        if ($user->group->is_trusted && !$request->boolean('mod_queue_opt_in')) {
             $appurl = config('app.url');
             $user = $torrent->user;
             $username = $user->username;

--- a/book/src/torrent_api.md
+++ b/book/src/torrent_api.md
@@ -89,6 +89,7 @@ Parameters:
 | `doubleup`*        | bool   | Should the torrent offer double upload?
 | `du_until`*        | int    | Number of days the torrent should offer double upload
 | `sticky`*          | bool   | Should the torrent be stickied on the torrent index?
+| `mod_queue_opt_in`*| bool   | Should the torrent be sent to moderation queue?
 
 *Only available to staff and internal users.
 


### PR DESCRIPTION
Same check in the HTTP controller that wasn't added to the torrent API. 

https://github.com/HDInnovations/UNIT3D/blob/2ca4451efc9d600e1f6c4edf967d010013788e3c/app/Http/Controllers/TorrentController.php#L473