### PR TITLE
(Fix) donor expiries overlapping instead of extending

### DIFF
--- a/app/Http/Controllers/Staff/DonationController.php
+++ b/app/Http/Controllers/Staff/DonationController.php
@@ -20,7 +20,7 @@ use App\Enums\ModerationStatus;
 use App\Helpers\StringHelper;
 use App\Models\Conversation;
 use App\Services\Unit3dAnnounce;
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use App\Models\Donation;
 use Illuminate\Http\Request;
 use App\Models\PrivateMessage;

--- a/app/Models/Donation.php
+++ b/app/Models/Donation.php
@@ -23,17 +23,17 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * App\Models\Donation.
  *
- * @property int                        $id
- * @property int                        $user_id
- * @property int                        $gifted_user_id
- * @property ModerationStatus           $status
- * @property int                        $package_id
- * @property string                     $transaction
- * @property bool                       $is_gifted
- * @property \Illuminate\Support\Carbon $starts_at
- * @property \Illuminate\Support\Carbon $ends_at
- * @property \Illuminate\Support\Carbon $created_at
- * @property \Illuminate\Support\Carbon $updated_at
+ * @property int                             $id
+ * @property int                             $user_id
+ * @property int                             $gifted_user_id
+ * @property ModerationStatus                $status
+ * @property int                             $package_id
+ * @property string                          $transaction
+ * @property bool                            $is_gifted
+ * @property \Illuminate\Support\Carbon      $starts_at
+ * @property \Illuminate\Support\Carbon|null $ends_at
+ * @property \Illuminate\Support\Carbon      $created_at
+ * @property \Illuminate\Support\Carbon      $updated_at
  */
 class Donation extends Model
 {


### PR DESCRIPTION
Apologies for the dupe #4673 still getting used to git.

> My last PR regarding this was abandoned and removed after I reset the fork, that being said this pull request updates the functionality of the donation approval so that when a user with an active donation decides to add another donation, instead of simply adding another donation to the table with the same values, it checks for all previous **active** donations and appends their remaining expiry to the new donation.