### PR TITLE
(add) Support for Cover and Banner Image URLs

### DIFF
--- a/app/Helpers/ImageHelper.php
+++ b/app/Helpers/ImageHelper.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D
+ *
+ * @author     CvT <convert.banister491@passinbox.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+namespace App\Helpers;
+
+use App\Models\WhitelistedImageUrl;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Intervention\Image\Facades\Image;
+use Illuminate\Support\Facades\Storage;
+
+class ImageHelper
+{
+    /**
+     * Process an image (file or URL) for torrent cover or banner.
+     *
+     * @param UploadedFile|string $source Image file or URL
+     * @param string $torrentId Torrent ID for naming
+     * @param string $type 'cover' or 'banner'
+     * @return array{path: string|null, url: string}|null
+     */
+    public static function processTorrentImage($source, string $torrentId, string $type): ?array
+    {
+        $handling = config('image.remote_image_handling');
+        $disk = $type === 'cover' ? 'torrent-covers' : 'torrent-banners';
+        $filename = "torrent-{$type}_{$torrentId}.webp";
+
+        // Handle Banner
+        if ($type === 'banner') {
+            return self::processBanner($source, $torrentId, $disk, $filename, $type);
+        }
+
+        // Handle Cover
+        if ($source instanceof UploadedFile) {
+            return self::processUploadedCover($source, $disk, $filename, $torrentId, $type);
+        }
+
+        if (!self::isValidImageUrl($source)) {
+            \Log::error("Invalid image URL in processTorrentImage", [
+                'url' => $source,
+                'torrent_id' => $torrentId,
+                'type' => $type,
+            ]);
+            return null;
+        }
+
+        if ($handling === 'use_url') {
+            return ['path' => null, 'url' => $source];
+        }
+
+        if ($handling === 'whitelist_or_save' && self::isWhitelistedUrl($source)) {
+            return ['path' => null, 'url' => $source];
+        }
+
+        // Save to server
+        $result = self::processRemoteCover($source, $disk, $filename, $torrentId, $type);
+        if (!$result) {
+            \Log::error("Failed to process remote cover in processTorrentImage", [
+                'url' => $source,
+                'torrent_id' => $torrentId,
+                'type' => $type,
+            ]);
+        }
+        return $result;
+    }
+
+    /**
+     * Validate if a URL points to a valid image.
+     */
+    private static function isValidImageUrl(string $url): bool
+    {
+        try {
+            $response = Http::timeout(5)->get($url);
+            if ($response->successful() && str_starts_with($response->header('Content-Type'), 'image/')) {
+                return true;
+            }
+            \Log::warning("Invalid image URL response", [
+                'url' => $url,
+                'status' => $response->status(),
+                'content_type' => $response->header('Content-Type'),
+            ]);
+            return false;
+        } catch (\Exception $e) {
+            \Log::error("Exception in isValidImageUrl", [
+                'url' => $url,
+                'error' => $e->getMessage(),
+            ]);
+            return false;
+        }
+    }
+
+    /**
+     * Check if a URL matches any whitelisted patterns from WhitelistedImageUrl model.
+     */
+    private static function isWhitelistedUrl(string $url): bool
+    {
+        $patterns = cache()->remember('whitelisted-image-urls', now()->addHour(), fn () => WhitelistedImageUrl::pluck('pattern')->toArray());
+
+        foreach ($patterns as $wildcard) {
+            $regex = self::wildcardToRegex($wildcard);
+
+            if (@preg_match($regex, $url)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function wildcardToRegex(string $wildcard): string
+    {
+        $escaped = preg_quote($wildcard, '/');
+        $regex = str_replace(['\*\*', '\*'], ['.*', '[^\/\.]*'], $escaped);
+        return '/^' . $regex . '$/i';
+    }
+
+    /**
+     * Process uploaded cover image
+     *
+     * @param UploadedFile $file
+     * @param string $disk
+     * @param string $filename
+     * @param string $torrentId
+     * @param string $type
+     * @return array{path: string, url: string}
+     */
+    private static function processUploadedCover(UploadedFile $file, string $disk, string $filename, string $torrentId, string $type): array
+    {
+        $path = Storage::disk($disk)->path($filename);
+        $image = Image::make($file->getRealPath());
+        $image->resize(500, 500, function ($constraint) {
+            $constraint->aspectRatio();
+            $constraint->upsize();
+        });
+        $image->encode('webp', 90)->save($path);
+        self::deleteUnusedTorrentImage($torrentId, $type, legacyOnly: true);
+        return ['path' => $filename, 'url' => url("authenticated-images/{$disk}/{$torrentId}.webp")];
+    }
+
+    /**
+     * Process remote cover image
+     *
+     * @param string $url
+     * @param string $disk
+     * @param string $filename
+     * @param string $torrentId
+     * @param string $type
+     * @return array{path: string, url: string}|null
+     */
+    private static function processRemoteCover(string $url, string $disk, string $filename, string $torrentId, string $type): ?array
+    {
+        try {
+            $response = Http::timeout(5)->get($url);
+            if (!$response->successful()) {
+                \Log::error("HTTP request failed in processRemoteCover", [
+                    'url' => $url,
+                    'status' => $response->status(),
+                    'headers' => $response->headers(),
+                ]);
+                return null;
+            }
+
+            $path = Storage::disk($disk)->path($filename);
+            $image = Image::make($response->body());
+            $image->resize(500, 500, function ($constraint) {
+                $constraint->aspectRatio();
+                $constraint->upsize();
+            });
+            $image->encode('webp', 90)->save($path);
+            self::deleteUnusedTorrentImage($torrentId, $type, legacyOnly: true);
+            return [
+                'path' => $filename,
+                'url' => url("authenticated-images/{$disk}/{$torrentId}.webp"),
+            ];
+        } catch (\Exception $e) {
+            \Log::error("Exception in processRemoteCover", [
+                'url' => $url,
+                'disk' => $disk,
+                'filename' => $filename,
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Process banner image
+     *
+     * @param UploadedFile|string $source
+     * @param string $torrentId
+     * @param string $disk
+     * @param string $filename
+     * @param string $type
+     * @return array{path: string|null, url: string}|null
+     */
+    private static function processBanner($source, string $torrentId, string $disk, string $filename, string $type): ?array
+    {
+        if ($source instanceof UploadedFile) {
+            $path = Storage::disk($disk)->path($filename);
+            Image::make($source->getRealPath())->fit(960, 540)->encode('webp', 90)->save($path);
+            self::deleteUnusedTorrentImage($torrentId, $type, legacyOnly: true);
+            return [
+                'path' => $filename,
+                'url' => url("authenticated-images/{$disk}/{$torrentId}.webp"),
+            ];
+        }
+
+        if (self::isValidImageUrl($source)) {
+            $handling = config('image.remote_image_handling');
+
+            if ($handling === 'use_url') {
+                return ['path' => null, 'url' => $source];
+            }
+
+            if ($handling === 'whitelist_or_save' && self::isWhitelistedUrl($source)) {
+                return ['path' => null, 'url' => $source];
+            }
+
+            try {
+                $response = Http::timeout(5)->get($source);
+                if ($response->successful()) {
+                    $path = Storage::disk($disk)->path($filename);
+                    $image = Image::make($response->body());
+                    $image->resize(500, 500, function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    });
+                    $image->encode('webp', 90)->save($path);
+                    self::deleteUnusedTorrentImage($torrentId, $type, legacyOnly: true);
+                    return [
+                        'path' => $filename,
+                        'url' => url("authenticated-images/{$disk}/{$torrentId}.webp"),
+                    ];
+                }
+            } catch (\Exception $e) {
+                \Log::error("Exception in processBanner", [
+                    'url' => $source,
+                    'torrent_id' => $torrentId,
+                    'disk' => $disk,
+                    'filename' => $filename,
+                    'error' => $e->getMessage(),
+                ]);
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Delete Torrent Image
+     */
+    public static function deleteUnusedTorrentImage(string $torrentId, string $type, bool $legacyOnly = false): void
+    {
+        $disk = $type === 'cover' ? 'torrent-covers' : 'torrent-banners';
+
+        $candidates = $legacyOnly
+            ? ["torrent-{$type}_{$torrentId}.jpg"]
+            : [
+                "torrent-{$type}_{$torrentId}.webp",
+                "torrent-{$type}_{$torrentId}.jpg",
+            ];
+
+        foreach ($candidates as $filename) {
+            if (Storage::disk($disk)->exists($filename)) {
+                Storage::disk($disk)->delete($filename);
+                break;
+            }
+        }
+    }
+}

--- a/app/Http/Controllers/API/TorrentController.php
+++ b/app/Http/Controllers/API/TorrentController.php
@@ -363,7 +363,7 @@ class TorrentController extends BaseController
         if ($request->hasFile('torrent-banner') && $request->filled('banner_url')) {
             return $this->sendError('Validation Error.', 'You can only provide either a cover image or a cover URL, not both.');
         }
-        
+
         if ($v->fails()) {
             if (Storage::disk('torrent-files')->exists($fileName)) {
                 Storage::disk('torrent-files')->delete($fileName);
@@ -379,7 +379,7 @@ class TorrentController extends BaseController
         if ($request->hasFile('torrent-cover') || $request->filled('cover_url')) {
             $source = $request->hasFile('torrent-cover') ? $request->file('torrent-cover') : (string) $request->string('cover_url');
 
-            if (is_array($source)) {
+            if (\is_array($source)) {
                 $source = $source[0];
             }
 
@@ -396,7 +396,7 @@ class TorrentController extends BaseController
         if ($request->hasFile('torrent-banner') || $request->filled('banner_url')) {
             $source = $request->hasFile('torrent-banner') ? $request->file('torrent-banner') : (string) $request->string('banner_url');
 
-            if (is_array($source)) {
+            if (\is_array($source)) {
                 $source = $source[0];
             }
 
@@ -407,7 +407,7 @@ class TorrentController extends BaseController
                     'banner_url' => $result['url'],
                 ]);
             }
-        }  
+        }
 
         // Populate the status/seeders/leechers/times_completed fields for the external tracker
         $torrent->refresh();
@@ -708,7 +708,7 @@ class TorrentController extends BaseController
                             ],
                             'name'             => $hit['name'],
                             'cover_url'        => $hit['cover_url'] ?? null,
-                            'banner_url'       => $hit['banner_url'] ?? null,                            
+                            'banner_url'       => $hit['banner_url'] ?? null,
                             'release_year'     => $meta['year'] ?? null,
                             'category'         => $hit['category']['name'] ?? null,
                             'type'             => $hit['type']['name'] ?? null,

--- a/app/Http/Controllers/AuthenticatedImageController.php
+++ b/app/Http/Controllers/AuthenticatedImageController.php
@@ -60,21 +60,31 @@ class AuthenticatedImageController extends Controller
 
     public function torrentBanner(Torrent $torrent): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
-        $path = Storage::disk('torrent-banners')->path("torrent-banner_{$torrent->id}.jpg");
-
-        abort_unless(file_exists($path), 404);
-
-        return response()->file($path, self::HEADERS);
+        $baseName = "torrent-banner_{$torrent->id}";
+        $pathWebp = Storage::disk('torrent-banners')->path("{$baseName}.webp");
+        $pathJpg  = Storage::disk('torrent-banners')->path("{$baseName}.jpg");
+    
+        if (file_exists($pathWebp)) {
+            return response()->file($pathWebp, self::HEADERS);
+        }
+    
+        abort_unless(file_exists($pathJpg), 404);
+        return response()->file($pathJpg, self::HEADERS);
     }
-
+    
     public function torrentCover(Torrent $torrent): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
-        $path = Storage::disk('torrent-covers')->path("torrent-cover_{$torrent->id}.jpg");
-
-        abort_unless(file_exists($path), 404);
-
-        return response()->file($path, self::HEADERS);
-    }
+        $baseName = "torrent-cover_{$torrent->id}";
+        $pathWebp = Storage::disk('torrent-covers')->path("{$baseName}.webp");
+        $pathJpg  = Storage::disk('torrent-covers')->path("{$baseName}.jpg");
+    
+        if (file_exists($pathWebp)) {
+            return response()->file($pathWebp, self::HEADERS);
+        }
+    
+        abort_unless(file_exists($pathJpg), 404);
+        return response()->file($pathJpg, self::HEADERS);
+    }   
 
     public function userAvatar(User $user): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {

--- a/app/Http/Controllers/AuthenticatedImageController.php
+++ b/app/Http/Controllers/AuthenticatedImageController.php
@@ -62,29 +62,31 @@ class AuthenticatedImageController extends Controller
     {
         $baseName = "torrent-banner_{$torrent->id}";
         $pathWebp = Storage::disk('torrent-banners')->path("{$baseName}.webp");
-        $pathJpg  = Storage::disk('torrent-banners')->path("{$baseName}.jpg");
-    
+        $pathJpg = Storage::disk('torrent-banners')->path("{$baseName}.jpg");
+
         if (file_exists($pathWebp)) {
             return response()->file($pathWebp, self::HEADERS);
         }
-    
+
         abort_unless(file_exists($pathJpg), 404);
+
         return response()->file($pathJpg, self::HEADERS);
     }
-    
+
     public function torrentCover(Torrent $torrent): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {
         $baseName = "torrent-cover_{$torrent->id}";
         $pathWebp = Storage::disk('torrent-covers')->path("{$baseName}.webp");
-        $pathJpg  = Storage::disk('torrent-covers')->path("{$baseName}.jpg");
-    
+        $pathJpg = Storage::disk('torrent-covers')->path("{$baseName}.jpg");
+
         if (file_exists($pathWebp)) {
             return response()->file($pathWebp, self::HEADERS);
         }
-    
+
         abort_unless(file_exists($pathJpg), 404);
+
         return response()->file($pathJpg, self::HEADERS);
-    }   
+    }
 
     public function userAvatar(User $user): \Symfony\Component\HttpFoundation\BinaryFileResponse
     {

--- a/app/Http/Controllers/TorrentController.php
+++ b/app/Http/Controllers/TorrentController.php
@@ -205,40 +205,40 @@ class TorrentController extends Controller
     }
 
     /**
-     * Helper for Cover/Banner Handling
+     * Helper for Cover/Banner Handling.
      */
     private function handleTorrentImage(Request $request, Torrent $torrent, string $inputName, string $urlField, string $type, bool $store = false): void
     {
-
         if ($request->hasFile($inputName) || $request->filled($urlField)) {
-           $source = $request->hasFile($inputName)
-               ? $request->file($inputName)
-               : (string) $request->string($urlField);
+            $source = $request->hasFile($inputName)
+                ? $request->file($inputName)
+                : (string) $request->string($urlField);
 
-           /** @var \Illuminate\Http\UploadedFile|string $source */
-           $result = ImageHelper::processTorrentImage($source, (string) $torrent->id, $type);
-    
-           if ($result) {
-               $newUrl = $result['url'];    
-               // Clean up unused file if External URL
-               if (!$store && !Str::contains($newUrl, "authenticated-images/torrent-{$type}s")) {
-                   ImageHelper::deleteUnusedTorrentImage((string) $torrent->id, $type);
-               }
-    
-               // Save the new URL
-               $torrent->{$urlField} = $newUrl;
-               $torrent->save();
-           } else {
-               Log::error("Failed to process {$type} image for torrent {$torrent->id}", [
-                   'source' => $source,
-               ]);
-               throw ValidationException::withMessages([
-                   $urlField => "Failed to process the {$type} image.",
-               ]);
-           }
-       }
-   }
+            /** @var \Illuminate\Http\UploadedFile|string $source */
+            $result = ImageHelper::processTorrentImage($source, (string) $torrent->id, $type);
 
+            if ($result) {
+                $newUrl = $result['url'];
+
+                // Clean up unused file if External URL
+                if (!$store && !Str::contains($newUrl, "authenticated-images/torrent-{$type}s")) {
+                    ImageHelper::deleteUnusedTorrentImage((string) $torrent->id, $type);
+                }
+
+                // Save the new URL
+                $torrent->{$urlField} = $newUrl;
+                $torrent->save();
+            } else {
+                Log::error("Failed to process {$type} image for torrent {$torrent->id}", [
+                    'source' => $source,
+                ]);
+
+                throw ValidationException::withMessages([
+                    $urlField => "Failed to process the {$type} image.",
+                ]);
+            }
+        }
+    }
 
     /**
      * Update the specified Torrent resource in storage.
@@ -268,7 +268,7 @@ class TorrentController extends Controller
         );
 
         $this->handleTorrentImage($request, $torrent, 'torrent-cover', 'cover_url', 'cover');
-        $this->handleTorrentImage($request, $torrent, 'torrent-banner', 'banner_url', 'banner');     
+        $this->handleTorrentImage($request, $torrent, 'torrent-banner', 'banner_url', 'banner');
 
         // Torrent Keywords System
         Keyword::where('torrent_id', '=', $torrent->id)->delete();
@@ -293,6 +293,7 @@ class TorrentController extends Controller
             $torrent->igdb !== null          => new IgdbScraper()->game($torrent->igdb),
             default                          => null,
         };
+
         return to_route('torrents.show', ['id' => $id])
             ->with('success', 'Successfully Edited!');
     }
@@ -351,7 +352,7 @@ class TorrentController extends Controller
 
         ImageHelper::deleteUnusedTorrentImage((string) $torrent->id, 'cover');
         ImageHelper::deleteUnusedTorrentImage((string) $torrent->id, 'banner');
-        
+
         Unit3dAnnounce::removeTorrent($torrent);
 
         $torrent->delete();

--- a/app/Http/Requests/StoreTorrentRequest.php
+++ b/app/Http/Requests/StoreTorrentRequest.php
@@ -63,8 +63,9 @@ class StoreTorrentRequest extends FormRequest
         $user = $request->user()->loadExists('internals');
         $category = Category::findOrFail($request->integer('category_id'));
 
-        $exclusiveImageSource = function (string $attribute, mixed $value, callable $fail) use ($request) {
-            $field = str_replace('torrent-', '', $attribute);   
+        $exclusiveImageSource = function (string $attribute, mixed $value, callable $fail) use ($request): void {
+            $field = str_replace('torrent-', '', $attribute);
+
             if ($request->filled("{$field}_url") && $request->hasFile($attribute)) {
                 $fail("Only (1) {$field} may be submitted, either by URL or file.");
             }
@@ -147,9 +148,9 @@ class StoreTorrentRequest extends FormRequest
                     'mimes:jpg,jpeg,png,webp',
                     'max:10240',
                     $exclusiveImageSource
-                    ]),
+                ]),
                 Rule::when(!($category->music_meta || $category->no_meta), [$mustBeNull]),
-                ],
+            ],
             'torrent-banner' => [
                 Rule::when($category->music_meta || $category->no_meta, [
                     'nullable',
@@ -157,9 +158,9 @@ class StoreTorrentRequest extends FormRequest
                     'mimes:jpg,jpeg,png,webp',
                     'max:10240',
                     $exclusiveImageSource
-                    ]),
+                ]),
                 Rule::when(!($category->music_meta || $category->no_meta), [$mustBeNull]),
-            ],         
+            ],
             'description' => [
                 'required',
                 'max:65535'

--- a/app/Http/Requests/UpdateTorrentRequest.php
+++ b/app/Http/Requests/UpdateTorrentRequest.php
@@ -63,8 +63,9 @@ class UpdateTorrentRequest extends FormRequest
         $torrent = Torrent::withoutGlobalScope(ApprovedScope::class)->find($torrentId);
         $user = $request->user()->load('group')->loadExists('internals');
 
-        $exclusiveImageSource = function (string $attribute, mixed $value, callable $fail) use ($request) {
-            $field = str_replace('torrent-', '', $attribute);   
+        $exclusiveImageSource = function (string $attribute, mixed $value, callable $fail) use ($request): void {
+            $field = str_replace('torrent-', '', $attribute);
+
             if ($request->filled("{$field}_url") && $request->hasFile($attribute)) {
                 $fail("Only (1) {$field} may be submitted, either by URL or file.");
             }
@@ -97,9 +98,9 @@ class UpdateTorrentRequest extends FormRequest
                     'mimes:jpg,jpeg,png,webp',
                     'max:10240',
                     $exclusiveImageSource
-                    ]),
+                ]),
                 Rule::when(!($category->music_meta || $category->no_meta), [$mustBeNull]),
-                ],
+            ],
             'torrent-banner' => [
                 Rule::when($category->music_meta || $category->no_meta, [
                     'nullable',
@@ -107,9 +108,9 @@ class UpdateTorrentRequest extends FormRequest
                     'mimes:jpg,jpeg,png,webp',
                     'max:10240',
                     $exclusiveImageSource
-                    ]),
+                ]),
                 Rule::when(!($category->music_meta || $category->no_meta), [$mustBeNull]),
-            ],          
+            ],
             'description' => [
                 'required',
                 'max:2097152'

--- a/app/Http/Resources/TorrentResource.php
+++ b/app/Http/Resources/TorrentResource.php
@@ -37,6 +37,8 @@ class TorrentResource extends JsonResource
                     'genres' => isset($this->meta->genres) ? collect($this->meta->genres)->pluck('name')->implode(', ') : '',
                 ],
                 'name'         => $this->name,
+                'cover_url'    => $this->cover_url,
+                'banner_url'   => $this->banner_url,
                 'release_year' => isset($this->meta->release_date) ? $this->meta->release_date->format('Y') : (isset($this->meta->first_air_date) ? $this->meta->first_air_date->format('Y') : null),
                 'category'     => $this->category->name,
                 'type'         => $this->type->name,

--- a/app/Models/Torrent.php
+++ b/app/Models/Torrent.php
@@ -152,10 +152,13 @@ class Torrent extends Model
         }
 
         $coverFile = "torrent-cover_{$this->id}";
+
         if (Storage::disk('torrent-covers')->exists("{$coverFile}.webp")) {
-            return route('authenticated_images.torrent_cover', ['torrent' => $this->id]) . '.webp';
-        } elseif (Storage::disk('torrent-covers')->exists("{$coverFile}.jpg")) {
-            return route('authenticated_images.torrent_cover', ['torrent' => $this->id]) . '.jpg';
+            return route('authenticated_images.torrent_cover', ['torrent' => $this->id]).'.webp';
+        }
+
+        if (Storage::disk('torrent-covers')->exists("{$coverFile}.jpg")) {
+            return route('authenticated_images.torrent_cover', ['torrent' => $this->id]).'.jpg';
         }
 
         return null;
@@ -171,10 +174,13 @@ class Torrent extends Model
         }
 
         $bannerFile = "torrent-banner_{$this->id}";
+
         if (Storage::disk('torrent-banners')->exists("{$bannerFile}.webp")) {
-            return route('authenticated_images.torrent_banner', ['torrent' => $this->id]) . '.webp';
-        } elseif (Storage::disk('torrent-banners')->exists("{$bannerFile}.jpg")) {
-            return route('authenticated_images.torrent_banner', ['torrent' => $this->id]) . '.jpg';
+            return route('authenticated_images.torrent_banner', ['torrent' => $this->id]).'.webp';
+        }
+
+        if (Storage::disk('torrent-banners')->exists("{$bannerFile}.jpg")) {
+            return route('authenticated_images.torrent_banner', ['torrent' => $this->id]).'.jpg';
         }
 
         return null;
@@ -936,7 +942,7 @@ class Torrent extends Model
 
         return [
             'id'                 => $torrent->id,
-            'name'               => $torrent->name,      
+            'name'               => $torrent->name,
             'description'        => $torrent->description,
             'mediainfo'          => $torrent->mediainfo,
             'bdinfo'             => $torrent->bdinfo,

--- a/app/Traits/Auditable.php
+++ b/app/Traits/Auditable.php
@@ -74,7 +74,7 @@ trait Auditable
                 // Process only what changed
                 foreach ($new as $key => $value) {
                     $data[$key] = [
-                        'old' => $old[$key],
+                        'old' => array_key_exists($key, $old) ? $old[$key] : null,
                         'new' => $value,
                     ];
                 }

--- a/app/Traits/Auditable.php
+++ b/app/Traits/Auditable.php
@@ -74,7 +74,7 @@ trait Auditable
                 // Process only what changed
                 foreach ($new as $key => $value) {
                     $data[$key] = [
-                        'old' => array_key_exists($key, $old) ? $old[$key] : null,
+                        'old' => \array_key_exists($key, $old) ? $old[$key] : null,
                         'new' => $value,
                     ];
                 }

--- a/book/src/torrent_api.md
+++ b/book/src/torrent_api.md
@@ -63,7 +63,11 @@ Parameters:
 |--------------------|--------|-------------
 | `torrent`          | file   | .torrent file
 | `nfo`              | file   | .nfo file
+| `torrent-cover`    | file   | cover image file
+| `torrent-banner`   | file   | banner image file
 | `name`             | string | Torrent name
+| `cover_url`        | string | Url to image (MIME: .jpg, .jpeg, .png, .webp)
+| `banner_url`       | string | Url to image (MIME: .jpg, .jpeg, .png, .webp)
 | `description`      | string | Torrent description
 | `mediainfo`        | string | MediaInfo text output
 | `bdinfo`           | string | BDInfo quick summary output

--- a/config/image.php
+++ b/config/image.php
@@ -39,4 +39,19 @@ return [
     */
 
     'max_upload_size' => '2000000',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Remote Image Handling (Torrent Uploads: no_meta or music_meta)
+    |--------------------------------------------------------------------------
+    |
+    | Determines whether to save remote images to the server or use the provided URL.
+    | Options: 'save_to_server', 'use_url', 'whitelist_or_save'
+    | - 'save_to_server': Always save images to server.
+    | - 'use_url': Always use the provided URL.
+    | - 'whitelist_or_save': Use URL if it matches a whitelisted pattern in WhitelistedImageUrl, otherwise save to server.
+    |
+    */
+    'remote_image_handling' =>  'whitelist_or_save',    
+
 ];

--- a/config/image.php
+++ b/config/image.php
@@ -52,6 +52,5 @@ return [
     | - 'whitelist_or_save': Use URL if it matches a whitelisted pattern in WhitelistedImageUrl, otherwise save to server.
     |
     */
-    'remote_image_handling' =>  'whitelist_or_save',    
-
+    'remote_image_handling' => 'whitelist_or_save',
 ];

--- a/cspell.json
+++ b/cspell.json
@@ -153,6 +153,7 @@
 		"testuser",
 		"torrenttitle",
 		"torrent.revokefeatured",
+		"upsize",
 		"unorderedlist",
 		"userban",
 		"userlist",

--- a/database/migrations/2025_04_23_add_cover_and_banner_urls_to_torrents_table.php
+++ b/database/migrations/2025_04_23_add_cover_and_banner_urls_to_torrents_table.php
@@ -1,11 +1,14 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * NOTICE OF LICENSE.
  *
  * UNIT3D is open-sourced software licensed under the GNU Affero General Public License v3.0
  * The details is bundled with this project in the file LICENSE.txt.
  *
- * @project    UNIT3D 
+ * @project    UNIT3D
  *
  * @author     CvT <convert.banister491@passinbox.com>
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
@@ -15,8 +18,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('torrents', function (Blueprint $table): void {

--- a/database/migrations/2025_04_23_add_cover_and_banner_urls_to_torrents_table.php
+++ b/database/migrations/2025_04_23_add_cover_and_banner_urls_to_torrents_table.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D 
+ *
+ * @author     CvT <convert.banister491@passinbox.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->string('cover_url')->nullable()->after('name');
+            $table->string('banner_url')->nullable()->after('cover_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('torrents', function (Blueprint $table): void {
+            $table->dropColumn(['cover_url', 'banner_url']);
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -2100,6 +2100,8 @@ DROP TABLE IF EXISTS `torrents`;
 CREATE TABLE `torrents` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `cover_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `banner_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `description` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `mediainfo` longtext COLLATE utf8mb4_unicode_ci,
   `bdinfo` longtext COLLATE utf8mb4_unicode_ci,
@@ -2967,3 +2969,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (346,'2025_04_07_15
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (347,'2025_04_15_075631_add_description_to_playlist_categories',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (348,'2025_04_15_090705_create_playlist_suggestions',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (349,'2025_04_21_164330_add_certification_to_tmdb_metadata',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (350,'2025_04_23_add_cover_and_banner_urls_to_torrents_table',1);

--- a/resources/sass/pages/_torrents.scss
+++ b/resources/sass/pages/_torrents.scss
@@ -143,6 +143,12 @@
     border-radius: 5px;
 }
 
+.torrent-search--list__music-img {
+    width: 54px;
+    height: 54px;
+    border-radius: 5x;
+}
+
 .torrent-search--list__format {
     grid-area: format;
 }

--- a/resources/sass/themes/_revel.scss
+++ b/resources/sass/themes/_revel.scss
@@ -1303,6 +1303,11 @@ a:hover {
     border-radius: 0;
 }
 
+.torrent-search--list__music-img {
+    width: 34px;
+    border-radius: 0;
+}
+
 .torrent-search--list__format > div {
     display: grid;
     place-items: center;

--- a/resources/views/components/torrent/card.blade.php
+++ b/resources/views/components/torrent/card.blade.php
@@ -59,12 +59,8 @@
                             src="https://images.igdb.com/igdb/image/upload/t_cover_big/{{ $torrent->meta->cover_image_id }}.jpg"
                     
                             @break
-                        @case($torrent->category->music_meta)
-                            src="https://via.placeholder.com/160x240"
-                    
-                            @break
-                        @case($torrent->category->no_meta && Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg"))
-                            src="{{ route('authenticated_images.torrent_cover', ['torrent' => $torrent]) }}"
+                        @case($torrent->category->no_meta || $torrent->category->music_meta)
+                            src="{{ $torrent->cover ?? ($torrent->cover_image ?? 'https://via.placeholder.com/160x240') }}"
                     
                             @break
                     @endswitch

--- a/resources/views/components/torrent/row.blade.php
+++ b/resources/views/components/torrent/row.blade.php
@@ -54,29 +54,20 @@
 
                 @if ($torrent->category->music_meta)
                     <img
-                        src="https://via.placeholder.com/90x135"
-                        class="torrent-search--list__poster-img"
+                        src="{{ $torrent->cover ?? ($torrent->cover_image ?? 'https://via.placeholder.com/90x90') }}"
+                        class="torrent-search--list__music-img"
                         loading="lazy"
                         alt="{{ __('torrent.similar') }}"
                     />
                 @endif
 
                 @if ($torrent->category->no_meta)
-                    @if (Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg"))
-                        <img
-                            src="{{ route('authenticated_images.torrent_cover', ['torrent' => $torrent]) }}"
-                            class="torrent-search--list__poster-img"
-                            loading="lazy"
-                            alt="{{ __('torrent.similar') }}"
-                        />
-                    @else
-                        <img
-                            src="https://via.placeholder.com/400x600"
-                            class="torrent-search--list__poster-img"
-                            loading="lazy"
-                            alt="{{ __('torrent.similar') }}"
-                        />
-                    @endif
+                    <img
+                        src="{{ $torrent->cover ?? ($torrent->cover_image ?? 'https://via.placeholder.com/90x135') }}"
+                        class="torrent-search--list__poster-img"
+                        loading="lazy"
+                        alt="{{ __('torrent.similar') }}"
+                    />
                 @endif
             </a>
         </td>
@@ -94,7 +85,8 @@
                         @style([
                             'height: 32px',
                             'padding-top: 1px' => $torrent->category->movie_meta || $torrent->category->tv_meta,
-                            'padding-top: 12px' => ! ($torrent->category->movie_meta || $torrent->category->tv_meta),
+                            'padding-top: 6px' => $torrent->category->music_meta,
+                            'padding-top: 12px' => ! ($torrent->category->movie_meta || $torrent->category->tv_meta || $torrent->category->music_meta),
                         ])
                     />
                 @else
@@ -103,7 +95,8 @@
                         @style([
                             'font-size: 24px',
                             'padding-top: 1px' => $torrent->category->movie_meta || $torrent->category->tv_meta,
-                            'padding-top: 12px' => ! ($torrent->category->movie_meta || $torrent->category->tv_meta),
+                            'padding-top: 6px' => $torrent->category->music_meta,
+                            'padding-top: 12px' => ! ($torrent->category->movie_meta || $torrent->category->tv_meta || $torrent->category->music_meta),
                         ])
                     ></i>
                 @endif

--- a/resources/views/torrent/create.blade.php
+++ b/resources/views/torrent/create.blade.php
@@ -92,7 +92,29 @@
                         name="nfo"
                     />
                 </p>
-                <p class="form__group" x-show="cats[cat].type === 'no'">
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
+                    <label for="cover_url" class="form__label">
+                        Cover Image URL ({{ __('torrent.optional') }})
+                    </label>
+                    <input
+                        id="cover_url"
+                        class="form__text"
+                        type="url"
+                        name="cover_url"
+                        placeholder="https://example.com/cover.jpg"
+                        value="{{ old('cover_url') }}"
+                    />
+                    <span class="form__hint">
+                        Provide a URL to an image or upload a file below.
+                    </span>
+                </p>
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
                     <label for="torrent-cover" class="form__label">
                         Cover {{ __('torrent.file') }} ({{ __('torrent.optional') }})
                     </label>
@@ -100,11 +122,33 @@
                         id="torrent-cover"
                         class="upload-form-file form__file"
                         type="file"
-                        accept=".jpg, .jpeg"
+                        accept=".jpg,.jpeg,.png,.webp"
                         name="torrent-cover"
                     />
                 </p>
-                <p class="form__group" x-show="cats[cat].type === 'no'">
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
+                    <label for="banner_url" class="form__label">
+                        Banner Image URL ({{ __('torrent.optional') }})
+                    </label>
+                    <input
+                        id="banner_url"
+                        class="form__text"
+                        type="url"
+                        name="banner_url"
+                        placeholder="https://example.com/banner.jpg"
+                        value="{{ old('banner_url') }}"
+                    />
+                    <span class="form__hint">
+                        Provide a URL to an image or upload a file below.
+                    </span>
+                </p>
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
                     <label for="torrent-banner" class="form__label">
                         Banner {{ __('torrent.file') }} ({{ __('torrent.optional') }})
                     </label>
@@ -112,7 +156,7 @@
                         id="torrent-banner"
                         class="upload-form-file form__file"
                         type="file"
-                        accept=".jpg, .jpeg"
+                        accept=".jpg,.jpeg,.png,.webp"
                         name="torrent-banner"
                     />
                 </p>

--- a/resources/views/torrent/edit.blade.php
+++ b/resources/views/torrent/edit.blade.php
@@ -43,26 +43,70 @@
             >
                 @csrf
                 @method('PATCH')
-                <p class="form__group" x-show="cats[cat].type === 'no'">
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
+                    <label class="form__label" for="cover_url">
+                        Cover Image URL ({{ __('torrent.optional') }})
+                    </label>
+                    <input
+                        id="cover_url"
+                        class="form__text"
+                        type="url"
+                        name="cover_url"
+                        placeholder="https://example.com/cover.jpg"
+                        value="{{ old('cover_url', $torrent->cover_image_url) }}"
+                    />
+                    <span class="form__hint">
+                        Provide a URL to an image or upload a file below.
+                    </span>
+                </p>
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
                     <label class="form__label" for="torrent-cover">
                         Cover {{ __('torrent.file') }} ({{ __('torrent.optional') }})
                     </label>
                     <input
                         id="torrent-cover"
                         class="form__file"
-                        accept=".jpg, .jpeg, .png"
+                        accept=".jpg,.jpeg,.png,.webp"
                         name="torrent-cover"
                         type="file"
                     />
                 </p>
-                <p class="form__group" x-show="cats[cat].type === 'no'">
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
+                    <label class="form__label" for="banner_url">
+                        Banner Image URL ({{ __('torrent.optional') }})
+                    </label>
+                    <input
+                        id="banner_url"
+                        class="form__text"
+                        type="url"
+                        name="banner_url"
+                        placeholder="https://example.com/banner.jpg"
+                        value="{{ old('banner_url', $torrent->banner_image_url) }}"
+                    />
+                    <span class="form__hint">
+                        Provide a URL to an image or upload a file below.
+                    </span>
+                </p>
+                <p
+                    class="form__group"
+                    x-show="cats[cat].type === 'no' || cats[cat].type === 'music'"
+                >
                     <label class="form__label" for="torrent-banner">
                         Banner {{ __('torrent.file') }} ({{ __('torrent.optional') }})
                     </label>
                     <input
                         id="torrent-banner"
                         class="form__file"
-                        accept=".jpg, .jpeg, .png"
+                        accept=".jpg,.jpeg,.png,.webp"
                         name="torrent-banner"
                         type="file"
                     />

--- a/resources/views/torrent/partials/no_meta.blade.php
+++ b/resources/views/torrent/partials/no_meta.blade.php
@@ -1,16 +1,13 @@
 <section class="meta">
-    @if (Storage::disk('torrent-banners')->exists("torrent-banner_$torrent->id.jpg"))
-        <img
-            class="meta__backdrop"
-            src="{{ route('authenticated_images.torrent_banner', ['torrent' => $torrent->id]) }}"
-            alt=""
-        />
+    @if ($torrent->banner_image)
+        <img class="meta__backdrop" src="{{ $torrent->banner_image }}" alt="" />
     @endif
 
     <span class="meta__poster-link">
         <img
-            src="{{ Storage::disk('torrent-covers')->exists("torrent-cover_$torrent->id.jpg") ? route('authenticated_images.torrent_cover', ['torrent' => $torrent]) : 'https://via.placeholder.com/400x600' }}"
+            src="{{ $torrent->cover_image ?? 'https://via.placeholder.com/400x600' }}"
             class="meta__poster"
+            alt=""
         />
     </span>
     <div class="meta__actions">


### PR DESCRIPTION
# Add Support for Cover and Banner Image URLs 

## Description
This PR introduces support for uploading cover and banner images via URLs or files for `no_meta` and `music_meta` torrents, enhancing flexibility for users. It centralizes image processing, improves validation, and adds WebP support with fallback to JPG.

## Key Changes
- Added `cover_url` and `banner_url` fields to the `Torrent` model and API responses.
- Introduced `ImageHelper` class for centralized image processing, handling both uploaded files and remote URLs.
- Implemented validation for image files and mutual exclusivity between file uploads and URLs.
- Configured remote image handling with a `whitelist_or_save` option, allowing whitelisted URLs to be used directly or saving images to the server otherwise. (Else `save_to_server` or `use_url` configurable in `config\Image.php`)
- Updated views and controllers to support new image fields for `no_meta` and `music_meta` torrents.
- Added cleanup of unused images on torrent deletion to prevent storage bloat.
- Enhanced `AuthenticatedImageController` to prioritize WebP files with JPG fallback.
- Included migration to add `cover_url` and `banner_url` columns to the `torrents` table.
- Fixed phpStan errors and ran prettier on Blade templates via CI.

## Motivation
- Provide the API with ability to handle both torrent-cover and torrent-banner as `Http\TorrentController.php` does
- Provide users with the option to use external image URLs instead of uploading files, reducing server load for trusted sources.
- Improve image handling consistency and support modern WebP format for better performance.
- Enhance the user experience by supporting both `no_meta` and `music_meta` categories.

## Testing
- Tested uploading cover and banner images via files and URLs for `no_meta` and `music_meta` torrents.
- Verified mutual exclusivity validation (file vs. URL) in `StoreTorrentRequest` and `UpdateTorrentRequest`.
- Confirmed WebP conversion and fallback to JPG for stored images.
- Checked remote image handling with whitelisted and non-whitelisted URLs.
- Ensured unused images are deleted when torrents are removed.
- Validated UI updates in torrent creation/edit views and image display in torrent cards/rows.

## Dependencies
__None Added__ but for clarity..
- Requires the `intervention/image` package for image processing.
- Depends on the `WhitelistedImageUrl` model for URL whitelisting.

## Related Issues
Fixes Issue #3897 and Issue #3688 
Complete overhaul of Pull #4388, rebased. Dropped needless dependencies. Also added URL support for the site.

## Considerations
It is recommended that the API primarily use `cover_url` and `banner_url `for image input. By default, PHP has an `upload_max_filesize` limit of 2MB, but Nginx often enforces a stricter `client_max_body_size` of 1MB. This means larger uploads may be rejected by Nginx before Laravel validation can occur. To avoid these issues, API users should avoid sending files via `torrent-cover` and `torrent-banner`, and instead rely on the URL-based fields.

Using WebP is also recommended for its flexibility and efficiency. WebP can significantly reduce file sizes—for example, compressing a 10MB PNG to under 1MB—making it especially useful if users choose to self-host all images.

## Checklist
- [x] Tests pass locally and in CI.
- [x] Migration included for database changes.
- [x] Reviewed for security (e.g., URL validation, file type checks).