### PR TITLE
(Add) Event deletion condition

### DIFF
--- a/app/Http/Controllers/Staff/EventController.php
+++ b/app/Http/Controllers/Staff/EventController.php
@@ -64,6 +64,11 @@ class EventController extends Controller
      */
     public function destroy(Event $event): \Illuminate\Http\RedirectResponse
     {
+        if ($event->claimedPrizes()->exists()) {
+            return redirect()->route('staff.events.index')
+                ->withErrors('Cannot delete event because users have claimed prizes. You can mark it as inactive instead.');
+        }
+
         $event->delete();
 
         return to_route('staff.events.index');


### PR DESCRIPTION
- One cannot delete an event where users have already claimed a prize. Foreign key constraint stops this. So we implement a condition to prevent this and return message to mark the event as inactive instead.