### PR TITLE
(Fix) Comparison blocking arrow keys from working in chat

### DIFF
--- a/resources/views/partials/comparison.blade.php
+++ b/resources/views/partials/comparison.blade.php
@@ -27,8 +27,8 @@
         x-show="show"
         x-cloak
         x-on:click="show = false"
-        x-on:keydown.down.window.prevent.stop="$el.scrollBy(0, $el.getElementsByTagName('li')[0].offsetHeight)"
-        x-on:keydown.up.window.prevent.stop="$el.scrollBy(0, -1 * $el.getElementsByTagName('li')[0].offsetHeight)"
+        x-on:keydown.down.window="if (show) { $event.preventDefault(); $event.stopPropagation(); $el.scrollBy(0, $el.getElementsByTagName('li')[0].offsetHeight) }"
+        x-on:keydown.up.window="if (show) { $event.preventDefault(); $event.stopPropagation(); $el.scrollBy(0, -1 * $el.getElementsByTagName('li')[0].offsetHeight) }"
     >
         @foreach ($urls as $row)
             <li>
@@ -40,8 +40,8 @@
                             screen = $event.key;
                         }
                     "
-                    x-on:keydown.left.window.prevent.stop="screen = screen == 1 ? {{ \count($comparates) }} : screen - 1"
-                    x-on:keydown.right.window.prevent.stop="screen = screen == {{ \count($comparates) }} ? 1 : screen + 1"
+                    x-on:keydown.left.window="if (show) { $event.preventDefault(); $event.stopPropagation(); screen = screen == 1 ? {{ \count($comparates) }} : screen - 1 }"
+                    x-on:keydown.right.window="if (show) { $event.preventDefault(); $event.stopPropagation(); screen = screen == {{ \count($comparates) }} ? 1 : screen + 1 }"
                     x-on:mousemove.window="screen = Math.ceil(($event.clientX * {{ \count($comparates) }}) / window.innerWidth)"
                 >
                     @foreach ($row as $url)


### PR DESCRIPTION
Makes it so the arrow keys are only blocked when comparison is opened.