### PR TITLE
(Add) Turnstile

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -58,7 +58,7 @@ class CreateNewUser implements CreatesNewUsers
             ],
             'captcha' => [
                 Rule::excludeIf(config('captcha.enabled') === false),
-                Rule::when(config('captcha.enabled') === true, 'hiddencaptcha'),
+                Rule::when(config('captcha.enabled') === true, 'captcha'),
             ],
             'code' => [
                 Rule::when(config('other.invite-only') === true, [

--- a/app/Helpers/TurnstileCaptcha.php
+++ b/app/Helpers/TurnstileCaptcha.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class TurnstileCaptcha
+{
+    /**
+     * Render the Turnstile captcha.
+     */
+    public static function render(): string
+    {
+        return view('partials.turnstile')->render();
+    }
+
+    /**
+     * Validate the Turnstile response.
+     */
+    public static function check(array $formData): bool
+    {
+        $token = $formData['cf-turnstile-response'] ?? null;
+
+        if (!$token) {
+            return false;
+        }
+
+        if (!is_string($token)) {
+            return false;
+        }
+
+        if (strlen($token) < 100 || strlen($token) > 3000) {
+            return false;
+        }
+
+        try {
+            $response = Http::asForm()
+                ->timeout(5)
+                ->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
+                    'secret' => config('captcha.turnstile.secret_key'),
+                    'response' => $token,
+                    'remoteip' => request()->ip(),
+                ]);
+
+            if (!$response->successful()) {
+                return false;
+            }
+
+            $result = $response->json();
+            
+            if (!$result['success']) {
+                return false;
+            }
+
+            return true;
+
+        } catch (\Exception $e) {
+            Log::error('Turnstile: Exception during verification', [
+                'error' => $e->getMessage()
+            ]);
+            return false;
+        }
+    }
+} 

--- a/app/Helpers/TurnstileCaptcha.php
+++ b/app/Helpers/TurnstileCaptcha.php
@@ -19,6 +19,10 @@ class TurnstileCaptcha
 
     /**
      * Validate the Turnstile response.
+     *
+     * @param array<string, string> $formData The form data containing the turnstile response
+     *
+     * @throws \Exception
      */
     public static function check(array $formData): bool
     {

--- a/app/Helpers/TurnstileCaptcha.php
+++ b/app/Helpers/TurnstileCaptcha.php
@@ -23,7 +23,7 @@ class TurnstileCaptcha
      *
      * @param array<string, string> $formData The form data containing the turnstile response
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public static function check(array $formData): bool
     {

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -19,9 +19,30 @@ return [
     | Enabled
     |--------------------------------------------------------------------------
     |
-    | Hidden Captcha On/Off
+    | Captcha On/Off
     |
     */
 
     'enabled' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Type
+    |--------------------------------------------------------------------------
+    |
+    | Captcha system to use: 'hidden' or 'turnstile'
+    |     - hidden is a basic captcha that relies on randomly generated strings
+    |       and submission timing.
+    |
+    |     - turnstile is a highly secure captcha that uses Cloudflare Turnstile
+    |       bot detection but it requires a site key and secret key to use
+    |       https://developers.cloudflare.com/turnstile/get-started/#new-sites
+    */
+
+    'type' => env('CAPTCHA_TYPE', 'hidden'),
+
+    'turnstile' => [
+        'site_key' => env('TURNSTILE_SITE_KEY', ''),
+        'secret_key' => env('TURNSTILE_SECRET_KEY', ''),
+    ],
 ];

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -478,7 +478,8 @@ return [
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src
         'child-src' => [
             'allow' => [
-                'https://www.youtube-nocookie.com/embed/'
+                'https://www.youtube-nocookie.com/embed/',
+                'https://challenges.cloudflare.com/'
             ],
         ],
 
@@ -489,7 +490,8 @@ return [
             'allow' => [
                 'https://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
                 'wss://'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_HOST).(parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT) === null ? '' : ':'.parse_url(env('VITE_ECHO_ADDRESS'), PHP_URL_PORT)).'/socket.io/',
-                'https://api.themoviedb.org/',
+                'https://api.themoviedb.org/', 
+                'https://challenges.cloudflare.com/',
             ],
         ],
 
@@ -523,6 +525,11 @@ return [
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-src
         'frame-src' => [
+            'self' => true,
+            'allow' => [
+                'https://challenges.cloudflare.com',
+                'https://www.youtube-nocookie.com/embed/'
+            ],
         ],
 
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src

--- a/cspell.json
+++ b/cspell.json
@@ -30,6 +30,7 @@
 		"prewarn",
 		"prewarning",
 		"reindex",
+		"remoteip",
 		"remux",
 		"rsses",
 		"rsskey",

--- a/resources/sass/components/_captcha.scss
+++ b/resources/sass/components/_captcha.scss
@@ -1,0 +1,19 @@
+.turnstile-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin: 1.5rem 0;
+    background: transparent;
+
+    .cf-turnstile {
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        
+        iframe {
+            margin: 0 auto;
+            background: transparent;
+        }
+    }
+} 

--- a/resources/sass/pages/_auth.scss
+++ b/resources/sass/pages/_auth.scss
@@ -1,3 +1,5 @@
+@import '../components/captcha';
+
 body {
     height: 100vh;
     overflow-y: auto;

--- a/resources/views/auth/application/create.blade.php
+++ b/resources/views/auth/application/create.blade.php
@@ -156,7 +156,7 @@
                             </button>
                         </p>
                         @if (config('captcha.enabled'))
-                            @hiddencaptcha
+                            @captcha
                         @endif
 
                         <button class="auth-form__primary-button">{{ __('auth.apply') }}</button>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -97,7 +97,7 @@
                         </label>
                     </p>
                     @if (config('captcha.enabled'))
-                        @hiddencaptcha
+                        @captcha
                     @endif
 
                     <button class="auth-form__primary-button">{{ __('auth.login') }}</button>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -68,7 +68,7 @@
                         />
                     </p>
                     @if (config('captcha.enabled'))
-                        @hiddencaptcha
+                        @captcha
                     @endif
 
                     <button class="auth-form__primary-button">

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -95,7 +95,7 @@
                         />
                     </p>
                     @if (config('captcha.enabled'))
-                        @hiddencaptcha
+                        @captcha
                     @endif
 
                     <button class="auth-form__primary-button">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -118,7 +118,7 @@
                             />
                         </p>
                         @if (config('captcha.enabled'))
-                            @hiddencaptcha
+                            @captcha
                         @endif
 
                         <button class="auth-form__primary-button">{{ __('auth.signup') }}</button>

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -113,7 +113,7 @@
                         />
                     </p>
                     @if (config('captcha.enabled'))
-                        @hiddencaptcha
+                        @captcha
                     @endif
 
                     <button

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -59,7 +59,7 @@
                         @endif
                     </ul>
                     @if (config('captcha.enabled'))
-                        @hiddencaptcha
+                        @captcha
                     @endif
 
                     <details class="auth-form__dropdown">

--- a/resources/views/partials/turnstile.blade.php
+++ b/resources/views/partials/turnstile.blade.php
@@ -1,0 +1,7 @@
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer nonce="{{ HDVinnie\SecureHeaders\SecureHeaders::nonce() }}"></script>
+<div class="cf-turnstile" 
+    data-sitekey="{{ config('captcha.turnstile.site_key') }}"
+    data-theme="dark"
+    data-action="{{ Route::is('login') ? 'login' : (Route::is('register') ? 'register' : (Route::is('password.email') ? 'reset' : (Route::is('verification.send') ? 'verify' : 'auth'))) }}"
+    data-size="normal"
+    data-appearance="interactive"></div> 


### PR DESCRIPTION
While everybody LOVES the hidden captcha, it's got some major downsides that ruin the users experience. For one it frequently invalidates users especially on applications where they may be filling it out for a while and lose their progress only after clicking apply. Also it's not really a captcha but a repellent, which is why I think it's valuable for sites to invest in free turnstile for their domains and use it with unit3d. Turnstile is highly secure and cant be easily bypassed and it will prompt the user to reverify should there be any issues before continuing to the submit form. This is applied on all unauthenticated pages and only requires the following fields to be added to the sites environment:

```ini
CAPTCHA_TYPE=turnstile # by default it's the hidden captcha
TURNSTILE_SITE_KEY=0x00000000000000000 # these keys can be obtained from cloudflares dashboard, all it requires is a FQDN
TURNSTILE_SECRET_KEY=0x000000000000000
```
![image](https://github.com/user-attachments/assets/ed15fa80-46a0-483b-9888-6d95e7d0487f)

