### PR TITLE
(Fix) Homepage block settings

### DIFF
--- a/config/other.php
+++ b/config/other.php
@@ -165,6 +165,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default visible homepage blocks
+    |--------------------------------------------------------------------------
+    */
+    'default_news_visible'            => true,
+    'default_chat_visible'            => true,
+    'default_featured_visible'        => true,
+    'default_random_media_visible'    => true,
+    'default_poll_visible'            => true,
+    'default_top_torrents_visible'    => true,
+    'default_top_users_visible'       => true,
+    'default_latest_topics_visible'   => true,
+    'default_latest_posts_visible'    => true,
+    'default_latest_comments_visible' => true,
+    'default_online_visible'          => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Font Awesome Style
     |--------------------------------------------------------------------------
     | fas = Solid

--- a/database/migrations/2025_06_18_000000_add_homepage_block_settings_to_user_settings_table.php
+++ b/database/migrations/2025_06_18_000000_add_homepage_block_settings_to_user_settings_table.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class () extends Migration {
@@ -40,5 +41,9 @@ return new class () extends Migration {
             $table->boolean('latest_comments_visible')->default(true)->after('latest_posts_visible');
             $table->boolean('online_visible')->default(true)->after('latest_comments_visible');
         });
+
+        DB::table('user_settings')->update([
+            'chat_visible' => DB::raw('NOT chat_visible'),
+        ]);
     }
 };

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -3,50 +3,50 @@
 @section('page', 'page__home')
 
 @section('main')
-    @if ($user->settings?->news_visible)
+    @if ($user->settings?->news_visible ?? config('other.default_news_visible'))
         @include('blocks.news')
     @endif
 
-    @if ($user->settings?->chat_visible)
+    @if ($user->settings?->chat_visible ?? config('other.default_chat_visible'))
         <div id="vue">
             @include('blocks.chat')
         </div>
         @vite('resources/js/unit3d/chat.js')
     @endif
 
-    @if ($user->settings?->featured_visible)
+    @if ($user->settings?->featured_visible ?? config('other.default_featured_visible'))
         @include('blocks.featured')
     @endif
 
-    @if ($user->settings?->random_media_visible)
+    @if ($user->settings?->random_media_visible ?? config('other.default_random_media_visible'))
         @livewire('random-media')
     @endif
 
-    @if ($user->settings?->poll_visible)
+    @if ($user->settings?->poll_visible ?? config('other.default_poll_visible'))
         @include('blocks.poll')
     @endif
 
-    @if ($user->settings?->top_torrents_visible)
+    @if ($user->settings?->top_torrents_visible ?? config('other.default_top_torrents_visible'))
         @livewire('top-torrents')
     @endif
 
-    @if ($user->settings?->top_users_visible)
+    @if ($user->settings?->top_users_visible ?? config('other.default_top_users_visible'))
         @livewire('top-users')
     @endif
 
-    @if ($user->settings?->latest_topics_visible)
+    @if ($user->settings?->latest_topics_visible ?? config('other.default_latest_topics_visible'))
         @include('blocks.latest-topics')
     @endif
 
-    @if ($user->settings?->latest_posts_visible)
+    @if ($user->settings?->latest_posts_visible ?? config('other.default_latest_posts_visible'))
         @include('blocks.latest-posts')
     @endif
 
-    @if ($user->settings?->latest_comments_visible)
+    @if ($user->settings?->latest_comments_visible ?? config('other.default_latest_comments_visible'))
         @include('blocks.latest-comments')
     @endif
 
-    @if ($user->settings?->online_visible)
+    @if ($user->settings?->online_visible ?? config('other.default_online_visible'))
         @include('blocks.online')
     @endif
 @endsection

--- a/resources/views/user/general-setting/edit.blade.php
+++ b/resources/views/user/general-setting/edit.blade.php
@@ -223,7 +223,7 @@
                                 type="checkbox"
                                 name="news_visible"
                                 value="1"
-                                @checked($user->settings?->news_visible)
+                                @checked($user->settings?->news_visible ?? config('other.default_news_visible'))
                             />
                             {{ __('user.homepage-block-news-visible') }}
                         </label>
@@ -236,7 +236,7 @@
                                 type="checkbox"
                                 name="chat_visible"
                                 value="1"
-                                @checked($user->settings?->chat_visible)
+                                @checked($user->settings?->chat_visible ?? config('other.default_chat_visible'))
                             />
                             {{ __('user.homepage-block-chat-visible') }}
                         </label>
@@ -249,7 +249,7 @@
                                 type="checkbox"
                                 name="featured_visible"
                                 value="1"
-                                @checked($user->settings?->featured_visible)
+                                @checked($user->settings?->featured_visible ?? config('other.default_featured_visible'))
                             />
                             {{ __('user.homepage-block-featured-visible') }}
                         </label>
@@ -262,7 +262,7 @@
                                 type="checkbox"
                                 name="random_media_visible"
                                 value="1"
-                                @checked($user->settings?->random_media_visible)
+                                @checked($user->settings?->random_media_visible ?? config('other.default_random_media_visible'))
                             />
                             {{ __('user.homepage-block-random-media-visible') }}
                         </label>
@@ -275,7 +275,7 @@
                                 type="checkbox"
                                 name="poll_visible"
                                 value="1"
-                                @checked($user->settings?->poll_visible)
+                                @checked($user->settings?->poll_visible ?? config('other.default_poll_visible'))
                             />
                             {{ __('user.homepage-block-poll-visible') }}
                         </label>
@@ -288,7 +288,7 @@
                                 type="checkbox"
                                 name="top_torrents_visible"
                                 value="1"
-                                @checked($user->settings?->top_torrents_visible)
+                                @checked($user->settings?->top_torrents_visible ?? config('other.default_top_torrents_visible'))
                             />
                             {{ __('user.homepage-block-top-torrents-visible') }}
                         </label>
@@ -301,7 +301,7 @@
                                 type="checkbox"
                                 name="top_users_visible"
                                 value="1"
-                                @checked($user->settings?->top_users_visible)
+                                @checked($user->settings?->top_users_visible ?? config('other.default_top_users_visible'))
                             />
                             {{ __('user.homepage-block-top-users-visible') }}
                         </label>
@@ -314,7 +314,7 @@
                                 type="checkbox"
                                 name="latest_topics_visible"
                                 value="1"
-                                @checked($user->settings?->latest_topics_visible)
+                                @checked($user->settings?->latest_topics_visible ?? config('other.default_latest_topics_visible'))
                             />
                             {{ __('user.homepage-block-latest-topics-visible') }}
                         </label>
@@ -327,7 +327,7 @@
                                 type="checkbox"
                                 name="latest_posts_visible"
                                 value="1"
-                                @checked($user->settings?->latest_posts_visible)
+                                @checked($user->settings?->latest_posts_visible ?? config('other.default_latest_posts_visible'))
                             />
                             {{ __('user.homepage-block-latest-posts-visible') }}
                         </label>
@@ -340,7 +340,7 @@
                                 type="checkbox"
                                 name="latest_comments_visible"
                                 value="1"
-                                @checked($user->settings?->latest_comments_visible)
+                                @checked($user->settings?->latest_comments_visible ?? config('other.default_latest_comments_visible'))
                             />
                             {{ __('user.homepage-block-latest-comments-visible') }}
                         </label>
@@ -353,7 +353,7 @@
                                 type="checkbox"
                                 name="online_visible"
                                 value="1"
-                                @checked($user->settings?->online_visible)
+                                @checked($user->settings?->online_visible ?? config('other.default_online_visible'))
                             />
                             {{ __('user.homepage-block-online-visible') }}
                         </label>


### PR DESCRIPTION
The nullable user_setting was not checked and was being cast to false inside the if statement instead of falling back to configured defaults. This allows the site administration to configure and change defaults for their users without it affecting users who have explicitly chosen their existing user settings.