### PR TITLE
Fix: Reply to comment cancel button

### DIFF
--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -190,7 +190,7 @@
                             {{ __('common.comment') }}
                         </button>
                         <button
-                            type="button"
+                            type="reset"
                             wire:click="$toggle('isReplying')"
                             class="form__button form__button--text"
                         >


### PR DESCRIPTION
Cancel button doesn't clear the reply like it does when clicking cancel under a new comment, using the same type in `comments.php`.

https://github.com/HDInnovations/UNIT3D/blob/8b61b062ce9a63f69d044eac433090c0ef91c92a/resources/views/livewire/comments.blade.php#L35