### PR TITLE
(Fix) Follow Validation

### DIFF
--- a/app/Http/Controllers/User/FollowController.php
+++ b/app/Http/Controllers/User/FollowController.php
@@ -48,6 +48,12 @@ class FollowController extends Controller
                 ->withErrors(trans('user.follow-yourself'));
         }
 
+        // verify if user is following the target user already
+        if ($user->followers()->where('user_id', $request->user()->id)->exists()) {
+            return to_route('users.show', ['user' => $user])
+                ->withErrors(\sprintf('You are already following %s', $user->username));
+        }
+
         $user->followers()->attach($request->user()->id);
 
         $user->notify(new NewFollow('user', $request->user()));
@@ -61,6 +67,12 @@ class FollowController extends Controller
      */
     public function destroy(Request $request, User $user): \Illuminate\Http\RedirectResponse
     {
+        // verify if user is following the target user already
+        if (!$user->followers()->where('user_id', $request->user()->id)->exists()) {
+            return to_route('users.show', ['user' => $user])
+                ->withErrors(\sprintf('You\'re not following %s', $user->username));
+        }
+
         $user->followers()->detach($request->user()->id);
 
         $user->notify(new NewUnfollow('user', $request->user()));

--- a/tests/Feature/Http/Controllers/User/FollowControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/FollowControllerTest.php
@@ -18,6 +18,18 @@ use App\Models\User;
 use Database\Seeders\GroupSeeder;
 use Database\Seeders\UserSeeder;
 
+test('store returns an ok response', function (): void {
+    $this->seed(UserSeeder::class);
+    $this->seed(GroupSeeder::class);
+
+    $user = User::factory()->create();
+    $userToFollow = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('users.followers.store', ['user' => $userToFollow]));
+    $response->assertRedirect(route('users.show', ['user' => $userToFollow]))
+        ->assertSessionHas('success', \sprintf('You are now following %s', $userToFollow->username));
+});
+
 test('destroy returns an ok response', function (): void {
     $this->seed(UserSeeder::class);
     $this->seed(GroupSeeder::class);
@@ -43,16 +55,4 @@ test('index returns an ok response', function (): void {
     $response->assertViewIs('user.follower.index');
     $response->assertViewHas('followers');
     $response->assertViewHas('user', $user);
-});
-
-test('store returns an ok response', function (): void {
-    $this->seed(UserSeeder::class);
-    $this->seed(GroupSeeder::class);
-
-    $user = User::factory()->create();
-    $userToFollow = User::factory()->create();
-
-    $response = $this->actingAs($user)->post(route('users.followers.store', ['user' => $userToFollow]));
-    $response->assertRedirect(route('users.show', ['user' => $userToFollow]))
-        ->assertSessionHas('success', \sprintf('You are now following %s', $userToFollow->username));
 });

--- a/tests/Feature/Http/Controllers/User/FollowControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/FollowControllerTest.php
@@ -24,10 +24,11 @@ test('destroy returns an ok response', function (): void {
 
     $user = User::factory()->create();
     $userToFollow = User::factory()->create();
-    
+
     $followResponse = $this->actingAs($user)->post(route('users.followers.store', ['user' => $userToFollow]));
     $followResponse->assertRedirect(route('users.show', ['user' => $userToFollow]))
         ->assertSessionHas('success', \sprintf('You are now following %s', $userToFollow->username));
+
     $response = $this->actingAs($user)->delete(route('users.followers.destroy', ['user' => $userToFollow]));
     $response->assertRedirect(route('users.show', ['user' => $userToFollow]))
         ->assertSessionHas('success', \sprintf('You are no longer following %s', $userToFollow->username));

--- a/tests/Feature/Http/Controllers/User/FollowControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/FollowControllerTest.php
@@ -18,25 +18,16 @@ use App\Models\User;
 use Database\Seeders\GroupSeeder;
 use Database\Seeders\UserSeeder;
 
-test('store returns an ok response', function (): void {
-    $this->seed(UserSeeder::class);
-    $this->seed(GroupSeeder::class);
-
-    $user = User::factory()->create();
-    $userToFollow = User::factory()->create();
-
-    $response = $this->actingAs($user)->post(route('users.followers.store', ['user' => $userToFollow]));
-    $response->assertRedirect(route('users.show', ['user' => $userToFollow]))
-        ->assertSessionHas('success', \sprintf('You are now following %s', $userToFollow->username));
-});
-
 test('destroy returns an ok response', function (): void {
     $this->seed(UserSeeder::class);
     $this->seed(GroupSeeder::class);
 
     $user = User::factory()->create();
     $userToFollow = User::factory()->create();
-
+    
+    $followResponse = $this->actingAs($user)->post(route('users.followers.store', ['user' => $userToFollow]));
+    $followResponse->assertRedirect(route('users.show', ['user' => $userToFollow]))
+        ->assertSessionHas('success', \sprintf('You are now following %s', $userToFollow->username));
     $response = $this->actingAs($user)->delete(route('users.followers.destroy', ['user' => $userToFollow]));
     $response->assertRedirect(route('users.show', ['user' => $userToFollow]))
         ->assertSessionHas('success', \sprintf('You are no longer following %s', $userToFollow->username));
@@ -55,4 +46,16 @@ test('index returns an ok response', function (): void {
     $response->assertViewIs('user.follower.index');
     $response->assertViewHas('followers');
     $response->assertViewHas('user', $user);
+});
+
+test('store returns an ok response', function (): void {
+    $this->seed(UserSeeder::class);
+    $this->seed(GroupSeeder::class);
+
+    $user = User::factory()->create();
+    $userToFollow = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('users.followers.store', ['user' => $userToFollow]));
+    $response->assertRedirect(route('users.show', ['user' => $userToFollow]))
+        ->assertSessionHas('success', \sprintf('You are now following %s', $userToFollow->username));
 });


### PR DESCRIPTION
Currently a user is capable of sending repeated follow/unfollow requests which causes the site to respond incorrectly, unfollowing twice (even when you weren't already following) causes duplicated notifications and following twice causes a duplicate entry constraint violation error in the log. This solves it by checking if the user is already following before processing the follow/unfollow.