### PR TITLE
(Fix) Restore Chat Message Timestamps & Channel Swapping

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -466,7 +466,6 @@ document.addEventListener('alpine:init', () => {
         changeRoom(id) {
             this.state.chat.bot = 0;
             this.state.chat.target = 0;
-            this.state.chat.room = id;
             this.state.message.bot_id = null;
             this.state.message.receiver_id = null;
 
@@ -490,6 +489,8 @@ document.addEventListener('alpine:init', () => {
 
             // Set up room channel with improved connection handling
             channelHandler.setupRoom(id, this);
+
+            this.state.chat.room = id;
         },
 
         leaveRoom(id) {

--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -193,6 +193,7 @@ document.addEventListener('alpine:init', () => {
         typingTimeout: null,
         blurHandler: null,
         focusHandler: null,
+        timestampTick: 0,
 
         init() {
             this.state.chat.activeRoom = this.auth.chatroom.name;
@@ -216,6 +217,10 @@ document.addEventListener('alpine:init', () => {
                     this.state.ui.loading = false;
                     this.listenForChatter();
                     this.attachAudible();
+
+                    setInterval(() => {
+                        this.timestampTick++;
+                    }, 30000);
                 })
                 .catch((error) => {
                     console.error('Error initializing chat:', error);
@@ -764,6 +769,7 @@ document.addEventListener('alpine:init', () => {
 
         formatTime(timestamp) {
             if (!timestamp) return '';
+            this.timestampTick;
             return dayjs(timestamp).fromNow();
         },
     }));


### PR DESCRIPTION
When swapping channels it doesn't unsubscribe to the channel in the right order causing the user to be subscribed to both channels, this results in messages and typing indicators being merged into whatever channel the user is watching. Moving the unsubscribe method to after the room is setup fixes this issue, I've also added a timestamp tick.