### PR TITLE
(Remove) Chatbox autoscroll

### DIFF
--- a/resources/js/components/alpine/chatbox.js
+++ b/resources/js/components/alpine/chatbox.js
@@ -56,7 +56,6 @@ const messageHandler = {
                 if (context.$refs && context.$refs.message) {
                     context.$refs.message.value = '';
                 }
-                context.scrollToBottom();
             });
     },
 
@@ -109,7 +108,6 @@ const channelHandler = {
                 if (!context.state.chat.activeTab.startsWith('room')) return;
                 const message = context.processMessageCanMod(e.message);
                 context.messages.push(message);
-                context.scrollToBottom();
             })
             .listen('.new.ping', (e) => {
                 context.handlePing('room', e.ping.id);
@@ -316,7 +314,6 @@ document.addEventListener('alpine:init', () => {
                     .map((message) => this.processMessageCanMod(message))
                     .reverse();
                 this.state.ui.connecting = false;
-                this.scrollToBottom();
             } catch (error) {
                 console.error('Error fetching bot messages:', error);
                 this.state.ui.connecting = false;
@@ -335,7 +332,6 @@ document.addEventListener('alpine:init', () => {
                     .map((message) => this.processMessageCanMod(message))
                     .reverse();
                 this.state.ui.connecting = false;
-                this.scrollToBottom();
             } catch (error) {
                 console.error('Error fetching private messages:', error);
                 this.state.ui.connecting = false;
@@ -352,7 +348,6 @@ document.addEventListener('alpine:init', () => {
                     .map((message) => this.processMessageCanMod(message))
                     .reverse();
                 this.state.ui.connecting = false;
-                this.scrollToBottom();
             } catch (error) {
                 console.error('Error fetching messages:', error);
                 this.state.ui.connecting = false;
@@ -754,17 +749,6 @@ document.addEventListener('alpine:init', () => {
                 messageInput.value = '/gift ' + name + ' ';
                 messageInput.focus();
             }
-        },
-
-        scrollToBottom() {
-            this.$nextTick(() => {
-                if (this.$refs && this.$refs.messagesWrapper) {
-                    requestAnimationFrame(() => {
-                        this.$refs.messagesWrapper.scrollTop =
-                            this.$refs.messagesWrapper.scrollHeight;
-                    });
-                }
-            });
         },
 
         formatTime(timestamp) {


### PR DESCRIPTION
The Alpine chatbox scrolls to the bottom on every new message which gets irritating, in my testing environment on both desktop and mobile it seems like removing the scrollToBottom function makes it work just like before on the Vue chatbox. I've looked around in the old script but can't see any mention of scrolling to the bottom. Browsers by default should stick to the bottom on new messages without needing that scroll to bottom but if there's a better fix let me know.