### PR TITLE
Style: User list toggle & chat textbox

### DIFF
--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -48,7 +48,8 @@
 }
 
 #chatbox__messages-create:focus ~ .form__label--floating,
-#chatbox__messages-create:valid:not(:placeholder-shown) ~ .form__label--floating {
+#chatbox__messages-create:valid:not(:placeholder-shown)
+    ~ .form__label--floating {
     background-color: var(--panel-bg);
 }
 

--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -47,6 +47,11 @@
     max-height: 60vh;
 }
 
+#chatbox__messages-create:focus ~ .form__label--floating,
+#chatbox__messages-create:valid:not(:placeholder-shown) ~ .form__label--floating {
+    background-color: var(--panel-bg);
+}
+
 .chatbox-message {
     display: grid;
     grid-template-areas: 'aside header . menu' 'aside content content content';

--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -42,6 +42,8 @@
 }
 
 #chatbox__messages-create {
+    resize: vertical;
+    width: 100%;
     max-height: 60vh;
 }
 
@@ -184,8 +186,9 @@
 
 .chatroom-users__list {
     list-style-type: none;
-    overflow-y: scroll;
+    overflow-y: visible;
     padding: 0 0 0 20px;
+    overflow-x: hidden;
 }
 
 .chatroom-users__user {

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -67,7 +67,7 @@
     --chatbox-message-bg: #0f111a;
     --chatbox-button-fg: #fff;
     --chatbox-button-hover-fg: #fff;
-    --chatbox-users-bg: #302f34;
+    --chatbox-users-bg: #0f111a;
     --chatbox-tab-delete-fg: #c22222;
     --chatbox-tab-delete-bg: #444;
 


### PR DESCRIPTION
A few style tweaks, the user list toggle background color on the navy theme was missed when I added it, there's two pointless scrollbars that show up on the user list toggle that this removes, leaving only the vertical main one. The chat message form now only resizes vertically and the textbox label gets a background when it's focused on so it doesn't overlap with the textbox border.