### PR TITLE
(Fix) Chatbox Newlines & Chatbox Style

### DIFF
--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -44,6 +44,7 @@
 
 #chatbox__messages-create {
     max-height: 60vh;
+    resize: vertical;
 }
 
 .chatbox-message {

--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -28,6 +28,7 @@
     grid-area: users;
     width: auto;
     overflow-y: auto;
+    background-color: var(--chatbox-users-bg);
 }
 
 .chatroom__whispers {
@@ -143,37 +144,6 @@
     border-radius: 10%;
     border-width: 2px;
     border-style: solid;
-}
-
-.chatbox-message__fallback-avatar {
-    width: 34px;
-    height: 34px;
-    border-radius: 17px;
-}
-
-.chatbox-message__delete-button {
-    padding: 4px 12px;
-    margin: 0;
-    background-color: transparent;
-    text-align: center;
-    border: none;
-    color: transparent;
-    font-size: 14px;
-    cursor: pointer;
-}
-
-.chatbox-message:hover .chatbox-message__delete-button {
-    color: var(--chatbox-button-fg);
-    width: auto;
-
-    &:hover {
-        color: var(--chatbox-button-hover-fg);
-        width: auto;
-    }
-}
-
-.chatroom__users {
-    background-color: var(--chatbox-users-bg);
 }
 
 .chatroom-users__heading {

--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -19,7 +19,7 @@
     flex-direction: column;
     list-style-type: none;
     gap: 8px;
-    padding: 0 10px;
+    padding: 0 10px 5px;
     margin: 0;
     align-items: flex-start;
 }

--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -2,7 +2,7 @@
     display: grid;
     grid-template-areas: 'messages users' 'whispers users' 'new-message users';
     grid-template-columns: 1fr auto;
-    grid-template-rows: 1fr 18px auto;
+    grid-template-rows: 1fr auto auto;
     height: 700px;
     max-height: 90vh;
     background-color: inherit;
@@ -19,7 +19,7 @@
     flex-direction: column;
     list-style-type: none;
     gap: 8px;
-    padding: 0 10px 5px;
+    padding: 0 10px;
     margin: 0;
     align-items: flex-start;
 }

--- a/resources/sass/components/_chatbox.scss
+++ b/resources/sass/components/_chatbox.scss
@@ -35,6 +35,7 @@
     grid-area: whispers;
     font-size: 12px;
     padding: 2px 4px;
+    height: 18px;
 }
 
 .chatroom__new-message {

--- a/resources/views/blocks/chat.blade.php
+++ b/resources/views/blocks/chat.blade.php
@@ -415,7 +415,7 @@
                         name="message"
                         placeholder=" "
                         x-ref="message"
-                        @keydown.enter.prevent="createMessage($refs.message.value, true, auth.id, state.message.receiver_id, state.message.bot_id); $refs.message.value = ''"
+                        @keydown.enter="!$event.shiftKey && ($event.preventDefault(), createMessage($refs.message.value, true, auth.id, state.message.receiver_id, state.message.bot_id), $refs.message.value = '')"
                         @keyup="isTyping(auth)"
                     ></textarea>
                     <label class="form__label form__label--floating" for="chatbox__messages-create">


### PR DESCRIPTION
Users used to be able to create newlines by clicking shift enter but the way the alpine chatbox works any clicking of the enter key sends the message regardless. I've added an exception for holding shift, removed the horizontal resizing, and removed redundant and one unused chatbox css styles.