### PR TITLE
(Update) Set comparison colors on material themes to white

### DIFF
--- a/resources/sass/themes/_material-design-v3-amoled.scss
+++ b/resources/sass/themes/_material-design-v3-amoled.scss
@@ -76,8 +76,8 @@
     --compact-search-fg: #bbb;
     --compact-search-padding: 5px;
 
-    --comparison-divider-fg: #000;
-    --comparison-button-fg: #000;
+    --comparison-divider-fg: #fff;
+    --comparison-button-fg: #fff;
 
     --data-table-border-radius: 22px;
     --data-table-fg: #ccc;

--- a/resources/sass/themes/_material-design-v3-dark.scss
+++ b/resources/sass/themes/_material-design-v3-dark.scss
@@ -78,8 +78,8 @@
     --compact-search-fg: #bbb;
     --compact-search-padding: 5px;
 
-    --comparison-divider-fg: #000;
-    --comparison-button-fg: #000;
+    --comparison-divider-fg: #fff;
+    --comparison-button-fg: #fff;
 
     --data-table-border-radius: 22px;
     --data-table-fg: #c0c0c0;

--- a/resources/sass/themes/_material-design-v3-navy.scss
+++ b/resources/sass/themes/_material-design-v3-navy.scss
@@ -78,8 +78,8 @@
     --compact-search-fg: #bbb;
     --compact-search-padding: 5px;
 
-    --comparison-divider-fg: #000;
-    --comparison-button-fg: #000;
+    --comparison-divider-fg: #fff;
+    --comparison-button-fg: #fff;
 
     --data-table-border-radius: 22px;
     --data-table-fg: #c0c0c0;


### PR DESCRIPTION
Black is hardly visible on dark material design themes and impossible to see on amoled, this sets the dark material theme ones to white to match the other themes.