### PR TITLE
(Fix) Correct torrent request api controller name

### DIFF
--- a/app/Http/Controllers/API/TorrentRequestController.php
+++ b/app/Http/Controllers/API/TorrentRequestController.php
@@ -21,7 +21,7 @@ use App\Http\Resources\TorrentRequestResource;
 use App\Models\TorrentRequest;
 use Illuminate\Http\Request;
 
-class RequestController extends Controller
+class TorrentRequestController extends Controller
 {
     /**
      * Request search filter.

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,8 +48,8 @@ Route::middleware(['auth:'.AuthGuard::API->value, 'banned'])->group(function ():
 
     // Requests System
     Route::prefix('requests')->group(function (): void {
-        Route::get('/filter', [App\Http\Controllers\API\RequestController::class, 'filter']);
-        Route::get('/{id}', [App\Http\Controllers\API\RequestController::class, 'show'])->where('id', '[0-9]+');
+        Route::get('/filter', [App\Http\Controllers\API\TorrentRequestController::class, 'filter']);
+        Route::get('/{id}', [App\Http\Controllers\API\TorrentRequestController::class, 'show'])->where('id', '[0-9]+');
     });
 
     // User


### PR DESCRIPTION
A small name error in the route and controller make the API inaccessible.