### PR TITLE
(Update) use x-if templates instead of x-show for chat icons

### DIFF
--- a/resources/views/blocks/chat.blade.php
+++ b/resources/views/blocks/chat.blade.php
@@ -241,15 +241,15 @@
                                                     x-show="message.bot && message.bot.id >= 1 && (! message.user || message.user.id < 2)"
                                                     x-text="message.bot?.name || 'Unknown'"
                                                 ></span>
-                                                <i
-                                                    x-show="message.user?.icon !== null && message.user?.icon !== undefined"
-                                                >
-                                                    <img
-                                                        :style="'max-height: 16px; vertical-align: text-bottom;'"
-                                                        title="Custom User Icon"
-                                                        :src="'/authenticated-images/user-icons/' + message.user.username"
-                                                    />
-                                                </i>
+                                                <template x-if="message.user?.icon">
+                                                    <i>
+                                                        <img
+                                                            :style="'max-height: 16px; vertical-align: text-bottom;'"
+                                                            title="Custom User Icon"
+                                                            :src="'/authenticated-images/user-icons/' + message.user.username"
+                                                        />
+                                                    </i>
+                                                </template>
                                                 <i
                                                     x-show="message.user?.is_lifetime == 1"
                                                     class="fal fa-star"


### PR DESCRIPTION
Prevents unnecessary requests to custom user icons that don't exist. #4881