### PR TITLE
(Fix) Use correct model ID for my requests filtering

### DIFF
--- a/resources/views/livewire/torrent-reseed-search.blade.php
+++ b/resources/views/livewire/torrent-reseed-search.blade.php
@@ -9,7 +9,7 @@
                             id="myRequests"
                             class="form__checkbox"
                             type="checkbox"
-                            wire:model.live="show"
+                            wire:model.live="myRequests"
                         />
                         <label class="form__label" for="myRequests">
                             {{ __('request.my-requests') }}


### PR DESCRIPTION
Currently the checkbox does nothing and it errors out in console.