### PR TITLE
(Fix) Use meta title instead of name on rotten tomatoes meta button

### DIFF
--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -197,7 +197,7 @@
             <li class="meta__rotten">
                 <a
                     class="meta-id-tag"
-                    href="{{ href_rottentomatoes($meta->name, $meta->release_date) }}"
+                    href="{{ href_rottentomatoes($meta->title, $meta->release_date) }}"
                     title="Rotten Tomatoes: {{ $meta->title ?? '' }}  ({{ substr($meta->release_date ?? '', 0, 4) ?? '' }})"
                     target="_blank"
                     rel="noreferrer"


### PR DESCRIPTION
https://github.com/HDInnovations/UNIT3D/issues/4996#issuecomment-3316112577