### PR TITLE
(Fix) Remove or rename invalid model relations

### DIFF
--- a/app/Models/Announce.php
+++ b/app/Models/Announce.php
@@ -57,7 +57,7 @@ class Announce extends Model
      *
      * @return BelongsTo<Torrent, $this>
      */
-    public function torrents(): BelongsTo
+    public function torrent(): BelongsTo
     {
         return $this->belongsTo(Torrent::class);
     }
@@ -67,7 +67,7 @@ class Announce extends Model
      *
      * @return BelongsTo<User, $this>
      */
-    public function requests(): BelongsTo
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }

--- a/app/Models/Distributor.php
+++ b/app/Models/Distributor.php
@@ -57,14 +57,4 @@ class Distributor extends Model
     {
         return $this->hasMany(Torrent::class);
     }
-
-    /**
-     * Get the requests for this distributor.
-     *
-     * @return HasMany<TorrentRequest, $this>
-     */
-    public function requests(): HasMany
-    {
-        return $this->hasMany(TorrentRequest::class);
-    }
 }

--- a/app/Models/Region.php
+++ b/app/Models/Region.php
@@ -58,14 +58,4 @@ class Region extends Model
     {
         return $this->hasMany(Torrent::class);
     }
-
-    /**
-     * Get all requests for the region.
-     *
-     * @return HasMany<TorrentRequest, $this>
-     */
-    public function requests(): HasMany
-    {
-        return $this->hasMany(TorrentRequest::class);
-    }
 }


### PR DESCRIPTION
Requests don't have distributor or region relations, and Announce relations were renamed incorrectly. The relations don't appear to be used for anything currently.