### PR TITLE
Fix movie rotten tomatoes.

### DIFF
--- a/resources/views/torrent/partials/movie-meta.blade.php
+++ b/resources/views/torrent/partials/movie-meta.blade.php
@@ -197,7 +197,7 @@
             <li class="meta__rotten">
                 <a
                     class="meta-id-tag"
-                    href="{{ href_rottentomatoes($meta->name, $meta->release_date) }}"
+                    href="{{ href_rottentomatoes($meta->title, $meta->release_date) }}"
                     title="Rotten Tomatoes: {{ $meta->title ?? '' }}  ({{ substr($meta->release_date ?? '', 0, 4) ?? '' }})"
                     target="_blank"
                     rel="noreferrer"


### PR DESCRIPTION
This was introduced in 67a740d6aef78971c4a5bbf426162fe739389cd9 where a copy-paste error from TV used "name" instead of "title".