### PR TITLE
(Fix) Chatter types initialize to null

### DIFF
--- a/app/Events/Chatter.php
+++ b/app/Events/Chatter.php
@@ -30,19 +30,19 @@ class Chatter implements ShouldBroadcastNow
     use InteractsWithSockets;
     use SerializesModels;
 
-    public AnonymousResourceCollection $echoes;
+    public ?AnonymousResourceCollection $echoes = null;
 
-    public ChatMessageResource $message;
+    public ?ChatMessageResource $message = null;
 
     /**
-     * @var array{
+     * @var null|array{
      *     type: 'bot'|'target',
      *     id: int
      * }
      */
-    public array $ping;
+    public ?array $ping = null;
 
-    public AnonymousResourceCollection $audibles;
+    public ?AnonymousResourceCollection $audibles = null;
 
     /**
      * Chatter Constructor.


### PR DESCRIPTION
Laravel seems to be accessing the properties even if they're not set. Related: #5021.