### PR TITLE
(Fix) Don't send notifications to banned/disabled users

### DIFF
--- a/app/Console/Commands/AutoDeactivateWarning.php
+++ b/app/Console/Commands/AutoDeactivateWarning.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Group;
 use App\Models\Warning;
 use App\Notifications\UserWarningExpired;
 use App\Services\Unit3dAnnounce;
@@ -69,8 +70,17 @@ class AutoDeactivateWarning extends Command
                 $usersWithExpiredWarnings[$warning->user_id] = $warning->user;
             }, 100);
 
+        $inactiveGroupIds = Group::query()
+            ->whereIn('slug', ['banned', 'validating', 'disabled', 'pruned'])
+            ->pluck('id')
+            ->all();
+
         // Send a single notification for each user with expired warnings
         foreach ($usersWithExpiredWarnings as $user) {
+            if (\in_array($user->group_id, $inactiveGroupIds, true)) {
+                continue;
+            }
+
             $user->notify(new UserWarningExpired($user));
         }
 

--- a/app/Console/Commands/AutoPreWarning.php
+++ b/app/Console/Commands/AutoPreWarning.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Group;
 use App\Models\History;
 use App\Notifications\UserPreWarning;
 use Illuminate\Console\Command;
@@ -81,8 +82,17 @@ class AutoPreWarning extends Command
             $usersWithPreWarnings[$pre->user_id] = $pre->user;
         }
 
+        $inactiveGroupIds = Group::query()
+            ->whereIn('slug', ['banned', 'validating', 'disabled', 'pruned'])
+            ->pluck('id')
+            ->all();
+
         // Send a single notification for each user with warnings
         foreach ($usersWithPreWarnings as $user) {
+            if (\in_array($user->group_id, $inactiveGroupIds, true)) {
+                continue;
+            }
+
             $user->notify(new UserPreWarning($user));
         }
 

--- a/app/Console/Commands/AutoRemoveExpiredDonors.php
+++ b/app/Console/Commands/AutoRemoveExpiredDonors.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Group;
 use App\Models\User;
 use App\Notifications\DonationExpired;
 use App\Services\Unit3dAnnounce;
@@ -55,7 +56,16 @@ class AutoRemoveExpiredDonors extends Command
                 $query->where('ends_at', '>', now());
             })->get();
 
-        Notification::send($expiredDonors, new DonationExpired());
+        $inactiveGroupIds = Group::query()
+            ->whereIn('slug', ['banned', 'validating', 'disabled', 'pruned'])
+            ->pluck('id')
+            ->all();
+
+        // Notify active users only; donor status is still removed below.
+        Notification::send(
+            $expiredDonors->whereNotIn('group_id', $inactiveGroupIds),
+            new DonationExpired()
+        );
 
         foreach ($expiredDonors as $user) {
             $user->is_donor = false;

--- a/app/Console/Commands/AutoRemovePersonalFreeleech.php
+++ b/app/Console/Commands/AutoRemovePersonalFreeleech.php
@@ -50,9 +50,14 @@ class AutoRemovePersonalFreeleech extends Command
     {
         $personalFreeleech = PersonalFreeleech::query()->where('created_at', '<', now()->subDays(1))->get();
 
-        foreach ($personalFreeleech as $pfl) {
-            Notification::send(new User(['id' => $pfl->user_id]), new PersonalFreeleechDeleted());
+        $notifiableUsers = User::query()
+            ->whereIntegerInRaw('id', $personalFreeleech->pluck('user_id'))
+            ->whereDoesntHave('group', fn ($query) => $query->whereIn('slug', ['banned', 'validating', 'disabled', 'pruned']))
+            ->get();
 
+        Notification::send($notifiableUsers, new PersonalFreeleechDeleted());
+
+        foreach ($personalFreeleech as $pfl) {
             // Delete The Record From DB
             $pfl->delete();
 

--- a/app/Console/Commands/AutoWarning.php
+++ b/app/Console/Commands/AutoWarning.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Models\Group;
 use App\Models\History;
 use App\Models\User;
 use App\Models\Warning;
@@ -95,8 +96,17 @@ class AutoWarning extends Command
             $usersWithWarnings[$hr->user->id] = $hr->user;
         }
 
+        $inactiveGroupIds = Group::query()
+            ->whereIn('slug', ['banned', 'validating', 'disabled', 'pruned'])
+            ->pluck('id')
+            ->all();
+
         // Send a single notification for each user with warnings
         foreach ($usersWithWarnings as $user) {
+            if (\in_array($user->group_id, $inactiveGroupIds, true)) {
+                continue;
+            }
+
             $user->notify(new UserWarning($user));
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,6 +55,12 @@ parameters:
 			path: app/Console/Commands/AutoRecycleClaimedTorrentRequests.php
 
 		-
+			message: '#^Anonymous function should return Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\> but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Group\>\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Console/Commands/AutoRemovePersonalFreeleech.php
+
+		-
 			message: '#^Anonymous function should return Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\> but returns Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\History\>\.$#'
 			identifier: return.type
 			count: 1

--- a/tests/Unit/Console/Commands/AutoDeactivateWarningTest.php
+++ b/tests/Unit/Console/Commands/AutoDeactivateWarningTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * NOTICE OF LICENSE.
  *
@@ -13,6 +14,12 @@ declare(strict_types=1);
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
  */
 
+use App\Enums\UserGroup;
+use App\Models\User;
+use App\Models\Warning;
+use App\Notifications\UserWarningExpired;
+use Illuminate\Support\Facades\Notification;
+
 /**
  * @see App\Console\Commands\AutoDeactivateWarning
  */
@@ -20,6 +27,34 @@ it('runs successfully', function (): void {
     $this->artisan('auto:deactivate_warning')
         ->assertExitCode(0)
         ->run();
+});
 
-    // TODO: perform additional assertions to ensure the command behaved as expected
+it('deactivates expired warnings for everyone but only notifies active users', function (): void {
+    Notification::fake();
+
+    $staff = User::factory()->create(['group_id' => UserGroup::USER->value]);
+    $activeUser = User::factory()->create(['group_id' => UserGroup::USER->value]);
+    $bannedUser = User::factory()->create(['group_id' => UserGroup::BANNED->value]);
+    $prunedUser = User::factory()->create(['group_id' => UserGroup::USER->value]);
+    $prunedUser->delete();
+
+    foreach ([$activeUser, $bannedUser, $prunedUser] as $user) {
+        Warning::create([
+            'user_id'    => $user->id,
+            'warned_by'  => $staff->id,
+            'reason'     => 'Expired warning',
+            'expires_on' => now()->subDay(),
+            'active'     => true,
+        ]);
+    }
+
+    $this->artisan('auto:deactivate_warning')
+        ->assertExitCode(0)
+        ->run();
+
+    expect(Warning::query()->where('active', '=', true)->count())->toBe(0);
+
+    Notification::assertSentTo($activeUser, UserWarningExpired::class);
+    Notification::assertNotSentTo($bannedUser, UserWarningExpired::class);
+    Notification::assertNotSentTo($prunedUser, UserWarningExpired::class);
 });

--- a/tests/Unit/Console/Commands/AutoRemovePersonalFreeleechTest.php
+++ b/tests/Unit/Console/Commands/AutoRemovePersonalFreeleechTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * NOTICE OF LICENSE.
  *
@@ -13,6 +14,12 @@ declare(strict_types=1);
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
  */
 
+use App\Enums\UserGroup;
+use App\Models\PersonalFreeleech;
+use App\Models\User;
+use App\Notifications\PersonalFreeleechDeleted;
+use Illuminate\Support\Facades\Notification;
+
 /**
  * @see App\Console\Commands\AutoRemovePersonalFreeleech
  */
@@ -20,6 +27,30 @@ it('runs successfully', function (): void {
     $this->artisan('auto:remove_personal_freeleech')
         ->assertExitCode(0)
         ->run();
+});
 
-    // TODO: perform additional assertions to ensure the command behaved as expected
+it('removes expired personal freeleech for everyone but only notifies active users', function (): void {
+    Notification::fake();
+
+    $activeUser = User::factory()->create(['group_id' => UserGroup::USER->value]);
+    $bannedUser = User::factory()->create(['group_id' => UserGroup::BANNED->value]);
+    $prunedUser = User::factory()->create(['group_id' => UserGroup::USER->value]);
+    $prunedUser->delete();
+
+    foreach ([$activeUser, $bannedUser, $prunedUser] as $user) {
+        PersonalFreeleech::factory()->create([
+            'user_id'    => $user->id,
+            'created_at' => now()->subDays(2),
+        ]);
+    }
+
+    $this->artisan('auto:remove_personal_freeleech')
+        ->assertExitCode(0)
+        ->run();
+
+    expect(PersonalFreeleech::query()->count())->toBe(0);
+
+    Notification::assertSentTo($activeUser, PersonalFreeleechDeleted::class);
+    Notification::assertNotSentTo($bannedUser, PersonalFreeleechDeleted::class);
+    Notification::assertNotSentTo($prunedUser, PersonalFreeleechDeleted::class);
 });


### PR DESCRIPTION
Fixes #4869

The scheduled notification commands select users without checking account status, so banned and disabled users (who can't access the site) still get emailed: auto:warning, auto:prewarning, auto:deactivate_warning, auto:remove_expired_donors and auto:remove_personal_freeleech.

This skips the notification for validating/banned/disabled/pruned accounts (via UserGroup::inactiveIds()) while still performing the underlying state changes. For the hit-and-run commands that means a banned user still gets the warning row created and prewarned_at set; only the email is suppressed, so the warning history stays accurate if the account is later restored. Happy to exclude those accounts from the selection entirely instead if you'd prefer. AutoDeactivateWarning also gets a null guard, since a pruned (soft-deleted) user's warning->user resolves to null.

Tested with Pint, Larastan and PHPUnit, with added coverage for the group-exclusion and soft-deleted paths.