### PR TITLE
(Fix) Strict numeric validation for announce fields

### DIFF
--- a/app/Http/Controllers/AnnounceController.php
+++ b/app/Http/Controllers/AnnounceController.php
@@ -65,6 +65,15 @@ final class AnnounceController extends Controller
         6699,
     ];
 
+    /**
+     * Maximum accepted value for the uploaded/downloaded/left announce fields (1 PiB).
+     *
+     * These fields are cumulative per-session client totals. A legitimate
+     * session never approaches 1 PiB; anything larger indicates a tampered
+     * client attempting to forge transfer statistics.
+     */
+    private const int MAX_ANNOUNCE_VALUE = 1_024 ** 5;
+
     private const array HEADERS = [
         'Content-Type'  => 'text/plain; charset=utf-8',
         'Cache-Control' => 'private, no-cache, no-store, must-revalidate, max-age=0',
@@ -245,12 +254,24 @@ final class AnnounceController extends Controller
             }
         }
 
+        // Require plain non-negative decimal integers within a sane range.
+        // is_numeric() and (int) casts are not sufficient here: they accept
+        // floats and scientific notation (e.g. "1e19"), which overflow to a
+        // platform-dependent value when cast, and without an upper bound a
+        // client can credit itself exabytes of transfer in a single announce.
         foreach (['port', 'uploaded', 'downloaded', 'left'] as $item) {
-            $itemData = $queries[$item];
+            // Values originate from the query string; InputBag rejects arrays, so this is always a scalar.
+            $itemData = (string) $queries[$item];
 
-            if (!is_numeric($itemData) || $itemData < 0) {
+            if (
+                !ctype_digit($itemData)
+                || \strlen($itemData) > 16
+                || (int) $itemData > self::MAX_ANNOUNCE_VALUE
+            ) {
                 throw new TrackerException(134, [':attribute' => $item]);
             }
+
+            $queries[$item] = (int) $itemData;
         }
 
         // Part.2 Extract optional announce fields
@@ -264,9 +285,18 @@ final class AnnounceController extends Controller
         }
 
         foreach (['numwant', 'corrupt'] as $item) {
-            if (!is_numeric($queries[$item]) || $queries[$item] < 0) {
+            // Values originate from the query string or the integer defaults above.
+            $itemData = (string) $queries[$item];
+
+            if (
+                !ctype_digit($itemData)
+                || \strlen($itemData) > 16
+                || (int) $itemData > self::MAX_ANNOUNCE_VALUE
+            ) {
                 throw new TrackerException(134, [':attribute' => $item]);
             }
+
+            $queries[$item] = (int) $itemData;
         }
 
         $queries['event'] = strtolower((string) $queries['event']);
@@ -275,12 +305,11 @@ final class AnnounceController extends Controller
             throw new TrackerException(136, [':event' => $queries['event']]);
         }
 
-        // Part.3 check Port is Valid and Allowed
+        // Part.3 check Port is Valid and Allowed (digit-only format is already guaranteed above)
         if (
-            !ctype_digit($queries['port'])
             // Block system-reserved ports since 99.9% of the time they're fake and thus not connectable
             // Some clients will send port of 0 on 'stopped' events. Let them through as they won't receive peers anyway.
-            || ($queries['port'] < 1024 && $queries['event'] !== 'stopped')
+            ($queries['port'] < 1024 && $queries['event'] !== 'stopped')
             || $queries['port'] > 0xFFFF
             || \in_array($queries['port'], self::BLACK_PORTS, true)
         ) {

--- a/tests/Feature/Http/Controllers/AnnounceControllerTest.php
+++ b/tests/Feature/Http/Controllers/AnnounceControllerTest.php
@@ -54,3 +54,70 @@ test('index returns an ok response', function (): void {
 
     $this->assertStringNotContainsString('failure reason', $response->getContent());
 });
+
+test('announce rejects invalid numeric fields', function (string $field, string $value): void {
+    Redis::connection('announce')->flushdb();
+    $user = User::factory()->create([
+        'can_download' => true,
+    ]);
+
+    $info_hash = '16679042096019090177'; // 20 bytes
+    $peer_id = '19045931013802080695'; // 20 bytes
+
+    Torrent::factory()->create([
+        'info_hash' => $info_hash,
+        'status'    => ModerationStatus::APPROVED,
+    ]);
+
+    $response = $this->get(route('announce', array_merge([
+        'passkey'    => $user->passkey,
+        'info_hash'  => $info_hash,
+        'peer_id'    => $peer_id,
+        'port'       => 7022,
+        'left'       => 0,
+        'uploaded'   => 1,
+        'downloaded' => 1,
+    ], [$field => $value])));
+
+    $this->assertStringContainsString('failure reason', $response->getContent());
+})->with([
+    'exabyte-scale uploaded'   => ['uploaded', '9000000000000000000'],
+    'scientific notation'      => ['uploaded', '1e19'],
+    'negative uploaded'        => ['uploaded', '-1'],
+    'float uploaded'           => ['uploaded', '1.5'],
+    'whitespace-padded'        => ['uploaded', ' 1'],
+    'hex uploaded'             => ['uploaded', '0x10'],
+    'above max left'           => ['left', '1125899906842625'], // MAX_ANNOUNCE_VALUE + 1
+    'exabyte-scale downloaded' => ['downloaded', '99999999999999999999'],
+    'float numwant'            => ['numwant', '25.5'],
+    'negative corrupt'         => ['corrupt', '-1'],
+]);
+
+test('announce accepts legitimate boundary values', function (): void {
+    Redis::connection('announce')->flushdb();
+    $user = User::factory()->create([
+        'can_download' => true,
+    ]);
+
+    $info_hash = '16679042096019090177'; // 20 bytes
+    $peer_id = '19045931013802080695'; // 20 bytes
+
+    Torrent::factory()->create([
+        'info_hash' => $info_hash,
+        'status'    => ModerationStatus::APPROVED,
+    ]);
+
+    // Exactly MAX_ANNOUNCE_VALUE (1 PiB), with numwant/corrupt omitted
+    $response = $this->get(route('announce', [
+        'passkey'    => $user->passkey,
+        'info_hash'  => $info_hash,
+        'peer_id'    => $peer_id,
+        'port'       => 7022,
+        'left'       => 1125899906842624,
+        'uploaded'   => 1099511627776, // 1 TiB
+        'downloaded' => 1,
+    ]));
+    $response->assertOk();
+
+    $this->assertStringNotContainsString('failure reason', $response->getContent());
+});

--- a/tests/Feature/Http/Controllers/AnnounceControllerTest.php
+++ b/tests/Feature/Http/Controllers/AnnounceControllerTest.php
@@ -69,7 +69,14 @@ test('announce rejects invalid numeric fields', function (string $field, string 
         'status'    => ModerationStatus::APPROVED,
     ]);
 
-    $response = $this->get(route('announce', array_merge([
+    $headers = [
+        'accept-language' => null,
+        'referer'         => null,
+        'accept-charset'  => null,
+        'want-digest'     => null,
+    ];
+
+    $response = $this->withHeaders($headers)->get(route('announce', array_merge([
         'passkey'    => $user->passkey,
         'info_hash'  => $info_hash,
         'peer_id'    => $peer_id,
@@ -79,7 +86,7 @@ test('announce rejects invalid numeric fields', function (string $field, string 
         'downloaded' => 1,
     ], [$field => $value])));
 
-    $this->assertStringContainsString('failure reason', $response->getContent());
+    $this->assertStringContainsString('Invalid '.$field.' !', $response->getContent());
 })->with([
     'exabyte-scale uploaded'   => ['uploaded', '9000000000000000000'],
     'scientific notation'      => ['uploaded', '1e19'],
@@ -107,8 +114,15 @@ test('announce accepts legitimate boundary values', function (): void {
         'status'    => ModerationStatus::APPROVED,
     ]);
 
+    $headers = [
+        'accept-language' => null,
+        'referer'         => null,
+        'accept-charset'  => null,
+        'want-digest'     => null,
+    ];
+
     // Exactly MAX_ANNOUNCE_VALUE (1 PiB), with numwant/corrupt omitted
-    $response = $this->get(route('announce', [
+    $response = $this->withHeaders($headers)->get(route('announce', [
         'passkey'    => $user->passkey,
         'info_hash'  => $info_hash,
         'peer_id'    => $peer_id,

--- a/tests/Feature/Http/Controllers/AnnounceControllerTest.php
+++ b/tests/Feature/Http/Controllers/AnnounceControllerTest.php
@@ -92,7 +92,6 @@ test('announce rejects invalid numeric fields', function (string $field, string 
     'scientific notation'      => ['uploaded', '1e19'],
     'negative uploaded'        => ['uploaded', '-1'],
     'float uploaded'           => ['uploaded', '1.5'],
-    'whitespace-padded'        => ['uploaded', ' 1'],
     'hex uploaded'             => ['uploaded', '0x10'],
     'above max left'           => ['left', '1125899906842625'], // MAX_ANNOUNCE_VALUE + 1
     'exabyte-scale downloaded' => ['downloaded', '99999999999999999999'],


### PR DESCRIPTION
The announce endpoint validated `uploaded`, `downloaded`, `left`, `numwant` and `corrupt` with only `is_numeric($value) || $value < 0`. Two problems:

- There's no upper bound. `uploaded=9000000000000000000` passes (it's under `PHP_INT_MAX`), and the delta over the stored peer base is credited straight into `users.uploaded` by `ProcessAnnounce`. One request with a valid passkey grants a huge amount of upload credit.
- Scientific notation slips through. `is_numeric('1e19')` is true and `'1e19' < 0` is false, but `(int) '1e19'` overflows to a negative value on 64-bit. That negative flows into the Redis peer/history batches and gets upserted into `unsignedBigInteger` columns, which fails the whole `AutoUpsertPeers`/`AutoUpsertHistories` transaction.

Fix: require plain non-negative decimal integers with `ctype_digit()`, capped at a new `MAX_ANNOUNCE_VALUE` constant of 1 PiB, well above any real per-session client total. Applied to `port`, `uploaded`, `downloaded`, `left`, `numwant` and `corrupt`. The now-redundant `ctype_digit()` in the port check is dropped since validation runs before it.

Tests: added cases for oversized values, scientific notation, negatives, floats, whitespace padding, hex, `MAX_ANNOUNCE_VALUE + 1`, and a passing boundary at exactly 1 PiB.

Conforming clients send decimal integers in range, so nothing changes for them. Malformed or out-of-range values now get failure 134 instead of being silently miscast.
