### PR TITLE
feat: dual-stack (IPv4/IPv6) peer columns and views

### DIFF
--- a/app/Http/Controllers/TorrentPeerController.php
+++ b/app/Http/Controllers/TorrentPeerController.php
@@ -32,10 +32,18 @@ class TorrentPeerController extends Controller
 
         return view('torrent.peers', [
             'torrent' => $torrent,
+            // Dual-stack aware: ONE row per peer (it is a single peer with a
+            // single progress), but exposing BOTH IP families so the blade can
+            // show the IPv4 and IPv6 addresses together in one entry.
             'peers'   => Peer::query()
                 ->with('user.group')
-                ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'port', 'agent', 'created_at', 'updated_at', 'seeder', 'active', 'visible', 'connectable'])
-                ->selectRaw('INET6_NTOA(ip) as ip')
+                ->select(['torrent_id', 'user_id', 'uploaded', 'downloaded', 'left', 'agent', 'created_at', 'updated_at', 'seeder', 'active', 'visible', 'connectable'])
+                ->selectRaw('INET6_NTOA(ipv4) as ipv4_ip')
+                ->selectRaw('ipv4_port')
+                ->selectRaw('ipv4_connectable')
+                ->selectRaw('INET6_NTOA(ipv6) as ipv6_ip')
+                ->selectRaw('ipv6_port')
+                ->selectRaw('ipv6_connectable')
                 ->where('torrent_id', '=', $id)
                 ->orderByRaw('user_id = ? DESC', [$request->user()->id])
                 ->orderByDesc('active')

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -95,18 +95,28 @@ class UserController extends Controller
             'boughtUpload' => BonTransactions::where('sender_id', '=', $user->id)->where([['name', 'like', '%Upload%']])->sum('cost'),
             // 'boughtDownload'        => BonTransactions::where('sender_id', '=', $user->id)->where([['name', 'like', '%Download%']])->sum('cost'),
             'invitedBy' => Invite::where('accepted_by', '=', $user->id)->first(),
-            'clients'   => $user->peers()
-                ->join('torrents', 'torrents.id', '=', 'peers.torrent_id')
-                ->select('agent', 'port')
-                ->selectRaw('INET6_NTOA(peers.ip) as ip')
-                ->selectRaw('MIN(peers.created_at) as created_at')
-                ->selectRaw('MAX(peers.updated_at) as updated_at')
-                ->selectRaw('SUM(torrents.size) as size')
-                ->selectRaw('COUNT(*) as num_peers')
-                ->selectRaw('MAX(peers.connectable) as connectable')
-                ->groupBy(['ip', 'port', 'agent'])
-                ->where('active', '=', true)
-                ->get(),
+            // Dual-stack aware: one row per IP family (IPv4 and IPv6) so a
+            // dual-stack peer shows two separate lines (same content, two
+            // addresses) instead of collapsing onto the legacy `ip` column.
+            'clients'   => (function () use ($user) {
+                $family = fn (string $ip, string $port, string $conn) => $user->peers()
+                    ->join('torrents', 'torrents.id', '=', 'peers.torrent_id')
+                    ->whereNotNull('peers.'.$ip)
+                    ->where('peers.active', '=', true)
+                    ->selectRaw("INET6_NTOA(peers.$ip) as ip")
+                    ->selectRaw("peers.$port as port")
+                    ->selectRaw('peers.agent as agent')
+                    ->selectRaw('MIN(peers.created_at) as created_at')
+                    ->selectRaw('MAX(peers.updated_at) as updated_at')
+                    ->selectRaw('SUM(torrents.size) as size')
+                    ->selectRaw('COUNT(*) as num_peers')
+                    ->selectRaw("MAX(peers.$conn) as connectable")
+                    ->groupBy("peers.$ip", "peers.$port", 'peers.agent');
+
+                return $family('ipv6', 'ipv6_port', 'ipv6_connectable')
+                    ->union($family('ipv4', 'ipv4_port', 'ipv4_connectable'))
+                    ->get();
+            })(),
             'achievements' => AchievementProgress::with('details')
                 ->where('achiever_id', '=', $user->id)
                 ->whereNotNull('unlocked_at')

--- a/app/Models/Peer.php
+++ b/app/Models/Peer.php
@@ -50,14 +50,20 @@ final class Peer extends Model
     /**
      * Get the attributes that should be cast.
      *
-     * @return array{active: 'bool', seeder: 'bool', connectable: 'bool'}
+     * @return array{active: 'bool', seeder: 'bool', connectable: 'bool', ipv4_connectable: 'bool', ipv6_connectable: 'bool'}
      */
     protected function casts(): array
     {
         return [
-            'active'      => 'bool',
-            'seeder'      => 'bool',
-            'connectable' => 'bool',
+            'active'           => 'bool',
+            'seeder'           => 'bool',
+            'connectable'      => 'bool',
+            // Per-family connectability (dual-stack). Nullable in the DB: null
+            // means "no endpoint on this family", so the null-stays-null behavior
+            // of the bool cast is intentional — the blade only renders these when
+            // the corresponding ipv4_ip / ipv6_ip is present.
+            'ipv4_connectable' => 'bool',
+            'ipv6_connectable' => 'bool',
         ];
     }
 

--- a/database/migrations/2026_07_24_160000_add_dual_stack_columns_to_peers_table.php
+++ b/database/migrations/2026_07_24_160000_add_dual_stack_columns_to_peers_table.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Dual-stack support for UNIT3D-Announce.
+ *
+ * Adds per-family IPv4/IPv6 endpoint columns to `peers`. The Rust announcer
+ * reads/writes these columns directly (see src/queue/peer_update.rs and the
+ * .sqlx query cache), storing the address as raw bytes via INET6_ATON /
+ * ip_to_bytes(). Kept raw here (VARBINARY) rather than via Schema::binary()
+ * so the exact widths match what the announcer expects (4 bytes for IPv4,
+ * 16 for IPv6). Guarded so it is safe to re-run on a DB that already has them.
+ */
+return new class extends Migration
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $columns = [
+        'ipv4'             => 'VARBINARY(4) NULL DEFAULT NULL',
+        'ipv4_port'        => 'SMALLINT UNSIGNED NULL DEFAULT NULL',
+        'ipv4_connectable' => 'BOOLEAN NULL DEFAULT NULL',
+        'ipv6'             => 'VARBINARY(16) NULL DEFAULT NULL',
+        'ipv6_port'        => 'SMALLINT UNSIGNED NULL DEFAULT NULL',
+        'ipv6_connectable' => 'BOOLEAN NULL DEFAULT NULL',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->columns as $name => $definition) {
+            if (!Schema::hasColumn('peers', $name)) {
+                DB::statement("ALTER TABLE `peers` ADD COLUMN `{$name}` {$definition}");
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (array_keys($this->columns) as $name) {
+            if (Schema::hasColumn('peers', $name)) {
+                DB::statement("ALTER TABLE `peers` DROP COLUMN `{$name}`");
+            }
+        }
+    }
+};

--- a/resources/views/torrent/peers.blade.php
+++ b/resources/views/torrent/peers.blade.php
@@ -98,25 +98,61 @@
                             <td>{{ $peer->agent }}</td>
 
                             @if (auth()->user()->group->is_modo || auth()->id() == $peer->user_id)
-                                <td>{{ $peer->ip }}</td>
-                                <td>{{ $peer->port }}</td>
+                                <td>
+                                    @if ($peer->ipv4_ip)
+                                        <div>{{ $peer->ipv4_ip }}</div>
+                                    @endif
+                                    @if ($peer->ipv6_ip)
+                                        <div>{{ $peer->ipv6_ip }}</div>
+                                    @endif
+                                    @unless ($peer->ipv4_ip || $peer->ipv6_ip)
+                                        ---
+                                    @endunless
+                                </td>
+                                <td>
+                                    @if ($peer->ipv4_ip)
+                                        <div>{{ $peer->ipv4_port }}</div>
+                                    @endif
+                                    @if ($peer->ipv6_ip)
+                                        <div>{{ $peer->ipv6_port }}</div>
+                                    @endif
+                                </td>
                             @else
                                 <td>---</td>
                                 <td>---</td>
                             @endif
                             @if (\config('announce.connectable_check') == true)
-                                @php
-                                    $connectable = false;
-                                    if (config('announce.external_tracker.is_enabled')) {
-                                        $connectable = $peer->connectable;
-                                    } elseif (cache()->has('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent)) {
-                                        $connectable = cache()->get('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent);
-                                    }
-                                @endphp
+                                @if (config('announce.external_tracker.is_enabled'))
+                                    {{-- Dual-stack: report connectability per IP family, stacked like
+                                         the IP/Port columns, so a peer reachable on one family but not
+                                         the other is unambiguous (the legacy single flag hid this). --}}
+                                    <td>
+                                        @if ($peer->ipv4_ip)
+                                            <div class="{{ $peer->ipv4_connectable ? 'text-green' : 'text-red' }}">
+                                                IPv4: @choice('user.client-connectable-state', $peer->ipv4_connectable ? 1 : 0)
+                                            </div>
+                                        @endif
+                                        @if ($peer->ipv6_ip)
+                                            <div class="{{ $peer->ipv6_connectable ? 'text-green' : 'text-red' }}">
+                                                IPv6: @choice('user.client-connectable-state', $peer->ipv6_connectable ? 1 : 0)
+                                            </div>
+                                        @endif
+                                        @unless ($peer->ipv4_ip || $peer->ipv6_ip)
+                                            ---
+                                        @endunless
+                                    </td>
+                                @else
+                                    @php
+                                        $connectable = false;
+                                        if (cache()->has('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent)) {
+                                            $connectable = cache()->get('peers:connectable:' . $peer->ip . '-' . $peer->port . '-' . $peer->agent);
+                                        }
+                                    @endphp
 
-                                <td class="{{ $connectable ? 'text-green' : 'text-red' }}">
-                                    @choice('user.client-connectable-state', $connectable)
-                                </td>
+                                    <td class="{{ $connectable ? 'text-green' : 'text-red' }}">
+                                        @choice('user.client-connectable-state', $connectable)
+                                    </td>
+                                @endif
                             @endif
 
                             <td>


### PR DESCRIPTION
# feat: dual-stack (IPv4/IPv6) peer columns and views

## Summary

Surfaces both IP families for peers, to pair with the dual-stack
UNIT3D-Announce tracker. Adds `ipv4`/`ipv6` columns to the `peers` table and
shows both addresses — and per-family connectability — in the peer and profile
views.

> **Companion PR** — the tracker that populates these columns is in
> `lluiseduardo-silva/UNIT3D-Announce` (branch [`feat/dual-stack-ipv6`](https://github.com/lluiseduardo-silva/UNIT3D-Announce/tree/feat/dual-stack-ipv6)) The two
> are meant to ship together. [PR](https://github.com/Roardom/UNIT3D-Announce/pull/39)

## Changes

- **migration**: add nullable `ipv4`/`ipv6` address, `*_port` and
  `*_connectable` columns to `peers`.
- **torrent peers view**: show a peer's IPv4 and IPv6 endpoints stacked in one
  row, and report connectability **per family** (`IPv4: Yes/No`, `IPv6: Yes/No`)
  instead of a single ambiguous flag.
- **user profile** ("Clients and IP-addresses"): list both address families for
  a client.
- **Peer model / TorrentPeerController**: select and cast the per-family fields.

## Screenshots

- **Torrent peers** — IPv4/IPv6 addresses stacked per peer + the per-family
  `Connectable` column.
    
<img width="1935" height="238" alt="Captura de tela 2026-07-25 050903" src="https://github.com/user-attachments/assets/0d390506-b6b2-424a-bc6c-25e063325990" />

- **User profile** — both families under "Clients and IP-addresses".

<img width="2559" height="1439" alt="Captura de tela 2026-07-25 053145" src="https://github.com/user-attachments/assets/6dfff85a-ae23-4b0f-9661-47d8db773bdb" />

- **Before/after** — the same peer/torrent previously appeared multiple times
  because stale peers were never marked inactive in the DB; resolved by the
  companion tracker fix.
  
<img width="1909" height="370" alt="Captura de tela 2026-07-24 190658" src="https://github.com/user-attachments/assets/230c081b-94b5-429a-9bd2-6d688a51c06e" />

  "Active torrents"; after = clean peer view
  
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/f1347c64-559f-4858-9132-d07904cb7d15" />


## Notes

- Meaningful with the external dual-stack tracker enabled
  (`announce.external_tracker.is_enabled`) — the per-family connectivity data
  comes from the tracker's connect-back check.
- The `Connectable` column is gated by `announce.connectable_check` (default
  off, unchanged here).
- Migration only adds nullable columns; existing single-stack peers are
  unaffected.