### PR TITLE
(Fix) Exclude anonymous comments from public profile counts

### DIFF
--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -18,11 +18,14 @@ namespace App\Http\Controllers\User;
 
 use App\Enums\ModerationStatus;
 use App\Http\Controllers\Controller;
+use App\Models\Article;
 use App\Models\BonTransactions;
 use App\Models\Donation;
 use App\Models\History;
 use App\Models\Invite;
 use App\Models\Peer;
+use App\Models\Torrent;
+use App\Models\TorrentRequest;
 use App\Models\User;
 use App\Services\Unit3dAnnounce;
 use Assada\Achievements\Model\AchievementProgress;
@@ -42,6 +45,8 @@ class UserController extends Controller
      */
     public function show(Request $request, User $user): \Illuminate\Contracts\View\Factory|\Illuminate\View\View
     {
+        $canViewAnonymousComments = $request->user()->is($user) || $request->user()->group->is_modo;
+
         $user->load([
             'application',
             'privacy',
@@ -53,6 +58,15 @@ class UserController extends Controller
                 'torrents as non_anon_uploads_count' => fn ($query) => $query->where('anon', '=', false),
                 'topics',
                 'posts',
+                'comments as article_comments_count' => fn ($query) => $query
+                    ->whereHasMorph('commentable', [Article::class])
+                    ->when(!$canViewAnonymousComments, fn ($query) => $query->where('anon', '=', false)),
+                'comments as torrent_comments_count' => fn ($query) => $query
+                    ->whereHasMorph('commentable', [Torrent::class])
+                    ->when(!$canViewAnonymousComments, fn ($query) => $query->where('anon', '=', false)),
+                'comments as request_comments_count' => fn ($query) => $query
+                    ->whereHasMorph('commentable', [TorrentRequest::class])
+                    ->when(!$canViewAnonymousComments, fn ($query) => $query->where('anon', '=', false)),
                 'filledRequests' => fn ($query) => $query->whereNotNull('approved_by'),
                 'requests',
                 'warnings as active_warnings_count'       => fn ($query) => $query->where('active', '=', 1),

--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
         "chgrp",
 		"cinematographed",
 		"commentable",
+		"commentables",
 		"commenters",
 		"comparate",
 		"comparates",

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -1363,21 +1363,15 @@
                 <dl class="key-value">
                     <div class="key-value__group">
                         <dt>{{ __('user.article-comments') }}</dt>
-                        <dd>
-                            {{ $user->comments()->whereHasMorph('commentable', [App\Models\Article::class])->count() }}
-                        </dd>
+                        <dd>{{ $user->article_comments_count }}</dd>
                     </div>
                     <div class="key-value__group">
                         <dt>{{ __('user.torrent-comments') }}</dt>
-                        <dd>
-                            {{ $user->comments()->whereHasMorph('commentable', [App\Models\Torrent::class])->count() }}
-                        </dd>
+                        <dd>{{ $user->torrent_comments_count }}</dd>
                     </div>
                     <div class="key-value__group">
                         <dt>{{ __('user.request-comments') }}</dt>
-                        <dd>
-                            {{ $user->comments()->whereHasMorph('commentable', [App\Models\TorrentRequest::class])->count() }}
-                        </dd>
+                        <dd>{{ $user->request_comments_count }}</dd>
                     </div>
                 </dl>
             </section>

--- a/tests/Feature/Http/Controllers/User/UserControllerTest.php
+++ b/tests/Feature/Http/Controllers/User/UserControllerTest.php
@@ -14,8 +14,12 @@ declare(strict_types=1);
  * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
  */
 
+use App\Models\Article;
+use App\Models\Group;
 use App\Models\Invite;
 use App\Models\Peer;
+use App\Models\Torrent;
+use App\Models\TorrentRequest;
 use App\Models\User;
 
 test('accept rules returns an ok response', function (): void {
@@ -132,6 +136,87 @@ test('update aborts with a 403', function (): void {
     ]);
 
     $response->assertForbidden();
+});
+
+test('show excludes anonymous comments from another user\'s comment counts', function (): void {
+    $user = User::factory()->create();
+    $viewer = User::factory()->create();
+    $commentables = [
+        Article::factory()->create(),
+        Torrent::factory()->create(),
+        TorrentRequest::factory()->create(),
+    ];
+
+    foreach ($commentables as $commentable) {
+        $commentable->comments()->createMany([
+            [
+                'content' => 'Public comment',
+                'user_id' => $user->id,
+                'anon'    => false,
+            ],
+            [
+                'content' => 'Anonymous comment',
+                'user_id' => $user->id,
+                'anon'    => true,
+            ],
+        ]);
+    }
+
+    $response = $this->actingAs($viewer)->get(route('users.show', [$user]));
+
+    $response->assertOk();
+
+    $profileUser = $response->viewData('user');
+
+    expect([
+        $profileUser->article_comments_count,
+        $profileUser->torrent_comments_count,
+        $profileUser->request_comments_count,
+    ])->toBe([1, 1, 1]);
+});
+
+test('show includes anonymous comments in the author\'s own comment counts', function (): void {
+    $user = User::factory()->create();
+    $torrent = Torrent::factory()->create();
+
+    $torrent->comments()->createMany([
+        [
+            'content' => 'Public comment',
+            'user_id' => $user->id,
+            'anon'    => false,
+        ],
+        [
+            'content' => 'Anonymous comment',
+            'user_id' => $user->id,
+            'anon'    => true,
+        ],
+    ]);
+
+    $response = $this->actingAs($user)->get(route('users.show', [$user]));
+
+    $response->assertOk();
+
+    expect($response->viewData('user')->torrent_comments_count)->toBe(2);
+});
+
+test('show includes anonymous comments in comment counts for moderators', function (): void {
+    $user = User::factory()->create();
+    $torrent = Torrent::factory()->create();
+    $moderator = User::factory()->create([
+        'group_id' => Group::factory()->create(['is_modo' => true])->id,
+    ]);
+
+    $torrent->comments()->create([
+        'content' => 'Anonymous comment',
+        'user_id' => $user->id,
+        'anon'    => true,
+    ]);
+
+    $response = $this->actingAs($moderator)->get(route('users.show', [$user]));
+
+    $response->assertOk();
+
+    expect($response->viewData('user')->torrent_comments_count)->toBe(1);
 });
 
 // test cases...


### PR DESCRIPTION
Prevent anonymous comments from being included in comment totals displayed on another user's profile.
