### PR TITLE
(Add) User opt-out for Torrent Deleted Notifications

### DIFF
--- a/app/Http/Requests/UpsertUserNotificationRequest.php
+++ b/app/Http/Requests/UpsertUserNotificationRequest.php
@@ -45,6 +45,7 @@ class UpsertUserNotificationRequest extends FormRequest
             'show_torrent_comment'         => 'required|boolean',
             'show_torrent_thank'           => 'required|boolean',
             'show_torrent_tip'             => 'required|boolean',
+            'show_torrent_deleted'         => 'required|boolean',
             'show_mention_torrent_comment' => 'required|boolean',
             'show_mention_request_comment' => 'required|boolean',
             'show_mention_article_comment' => 'required|boolean',

--- a/app/Models/UserNotification.php
+++ b/app/Models/UserNotification.php
@@ -47,6 +47,7 @@ use Override;
  * @property int       $show_torrent_comment
  * @property int       $show_torrent_tip
  * @property int       $show_torrent_thank
+ * @property int       $show_torrent_deleted
  * @property int       $show_account_follow
  * @property int       $show_account_unfollow
  * @property list<int> $json_account_groups

--- a/app/Notifications/TorrentDeleted.php
+++ b/app/Notifications/TorrentDeleted.php
@@ -44,6 +44,22 @@ class TorrentDeleted extends Notification implements ShouldQueue, SystemNotifica
     }
 
     /**
+     * Determine if the notification should be sent.
+     */
+    public function shouldSend(User $notifiable): bool
+    {
+        if ($notifiable->notification?->block_notifications === 1) {
+            return false;
+        }
+
+        if ($notifiable->notification?->show_torrent_deleted === 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Get the array representation of the notification.
      *
      * @return array<string, mixed>

--- a/app/Notifications/TorrentsDeleted.php
+++ b/app/Notifications/TorrentsDeleted.php
@@ -48,6 +48,22 @@ class TorrentsDeleted extends Notification implements ShouldQueue, SystemNotific
     }
 
     /**
+     * Determine if the notification should be sent.
+     */
+    public function shouldSend(User $notifiable): bool
+    {
+        if ($notifiable->notification?->block_notifications === 1) {
+            return false;
+        }
+
+        if ($notifiable->notification?->show_torrent_deleted === 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Get the array representation of the notification.
      *
      * @return array<string, mixed>

--- a/database/factories/UserNotificationFactory.php
+++ b/database/factories/UserNotificationFactory.php
@@ -58,6 +58,7 @@ class UserNotificationFactory extends Factory
             'show_torrent_comment'         => $this->faker->boolean(),
             'show_torrent_tip'             => $this->faker->boolean(),
             'show_torrent_thank'           => $this->faker->boolean(),
+            'show_torrent_deleted'         => $this->faker->boolean(),
             'show_account_follow'          => $this->faker->boolean(),
             'show_account_unfollow'        => $this->faker->boolean(),
             'json_account_groups'          => Group::factory()->count(3)->create()->pluck('id')->toArray(),

--- a/database/migrations/2026_08_04_071256_add_show_torrent_deleted_to_user_notifications_table.php
+++ b/database/migrations/2026_08_04_071256_add_show_torrent_deleted_to_user_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE.
+ *
+ * UNIT3D Community Edition is open-sourced software licensed under the GNU Affero General Public License v3.0
+ * The details is bundled with this project in the file LICENSE.txt.
+ *
+ * @project    UNIT3D Community Edition
+ *
+ * @author     HDVinnie <hdinnovations@protonmail.com>
+ * @license    https://www.gnu.org/licenses/agpl-3.0.en.html/ GNU Affero General Public License v3.0
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_notifications', function (Blueprint $table): void {
+            $table->boolean('show_torrent_deleted')->index()->default(1)->after('show_torrent_thank');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -2408,6 +2408,7 @@ CREATE TABLE `user_notifications` (
   `show_torrent_comment` tinyint(1) NOT NULL DEFAULT '1',
   `show_torrent_tip` tinyint(1) NOT NULL DEFAULT '1',
   `show_torrent_thank` tinyint(1) NOT NULL DEFAULT '1',
+  `show_torrent_deleted` tinyint(1) NOT NULL DEFAULT '1',
   `show_account_follow` tinyint(1) NOT NULL DEFAULT '1',
   `show_account_unfollow` tinyint(1) NOT NULL DEFAULT '1',
   `json_account_groups` json NOT NULL,
@@ -2439,6 +2440,7 @@ CREATE TABLE `user_notifications` (
   KEY `user_notifications_show_torrent_comment_index` (`show_torrent_comment`),
   KEY `user_notifications_show_torrent_tip_index` (`show_torrent_tip`),
   KEY `user_notifications_show_torrent_thank_index` (`show_torrent_thank`),
+  KEY `user_notifications_show_torrent_deleted_index` (`show_torrent_deleted`),
   KEY `user_notifications_show_account_follow_index` (`show_account_follow`),
   KEY `user_notifications_show_account_unfollow_index` (`show_account_unfollow`),
   CONSTRAINT `user_notifications_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE CASCADE
@@ -3142,3 +3144,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (381,'2026_06_26_13
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (382,'2026_06_27_065215_rename_bounty_requests_id',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (383,'2026_06_27_193400_add_apikey_permissions',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (384,'2026_07_15_070539_remove_unused_ticket_columns',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (384,'2026_08_04_000000_add_show_torrent_deleted_to_user_notifications_table',1);

--- a/lang/en/user.php
+++ b/lang/en/user.php
@@ -383,6 +383,7 @@ return [
     'torrent-notification-comment' => 'Receive a notification when an uploaded torrent gets a new comment',
     'torrent-notification-thank'   => 'Receive a notification when an uploaded torrent gets a new thank',
     'torrent-notification-tip'     => 'Receive a notification when an uploaded torrent gets a new tip',
+    'torrent-notification-deleted' => 'Receive a notification when an uploaded, seeded or leeched torrent gets deleted',
     'torrent-notification-help'    => 'Control which notifications are sent concerning torrent activities.
     These settings are overridden if you do not allow any groups to send notifications concerning torrent activities or if you <strong>disable notifications</strong>',
     'torrent-privacy'          => 'Torrent settings',

--- a/resources/views/user/notification-setting/edit.blade.php
+++ b/resources/views/user/notification-setting/edit.blade.php
@@ -285,6 +285,19 @@
                             {{ __('user.torrent-notification-tip') }}
                         </label>
                     </p>
+                    <p class="form__group">
+                        <label class="form__label">
+                            <input type="hidden" name="show_torrent_deleted" value="0" />
+                            <input
+                                class="form__checkbox"
+                                type="checkbox"
+                                name="show_torrent_deleted"
+                                value="1"
+                                @checked($user->notification === null || $user->notification?->show_torrent_deleted)
+                            />
+                            {{ __('user.torrent-notification-deleted') }}
+                        </label>
+                    </p>
                 </fieldset>
                 <fieldset class="form__fieldset">
                     <legend class="form__legend">Mentions</legend>


### PR DESCRIPTION
_**Copied from my post on Blutopia:**_

I get many many notifications per week for "Torrent deleted" or "Bulk torrents deleted".
My inbox is drowning in them.
I end up having to click "Mark all messages as read" but this means I often miss important messages not related to torrent deletion.

I use qui for qbittorrent and it handles removing deleted torrents for me, but even if I didn't there are easier ways to remove deleted torrents from any torrenting program than manually cross-referencing with these notifications.

I am hoping an option could be added to "Settings > Notification > Torrents" to opt out of these notifications.

For what it's worth, this option was recently added to Nebulance to much fanfare. It would be great seeing it here too. 