### PR TITLE
(Update) Don't specify specific php redis version in ci

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,12 +16,10 @@ runs:
             uses: shivammathur/setup-php@v2
             with:
                 php-version: ${{ inputs.php-version }}
-                extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis-phpredis/phpredis@6.0.1
+                extensions: curl, dom, gd, libxml, mbstring, zip, mysql, xml, intl, bcmath, redis
                 ini-values: error_reporting=E_ALL
                 coverage: pcov
                 tools: composer:v2
-            env:
-                REDIS_CONFIGURE_OPTS: --enable-redis
 
         # 2. Composer Dependencies
         -   name: Get Composer cache directory


### PR DESCRIPTION
Avoids compiling it every commit. 15 seconds less time for every CI action using redis.