### PR TITLE
(Fix) mobile user profile; username area overflow

### DIFF
--- a/resources/sass/pages/_user.scss
+++ b/resources/sass/pages/_user.scss
@@ -1,21 +1,94 @@
+.profile__container {
+    container: user-profile / inline-size;
+    min-width: 0;
+    max-width: 100%;
+}
+
 .profileV2 {
     display: grid;
-    grid-template-columns: 200px minmax(min-content, auto) 1fr;
-    grid-template-areas: 'avatar username .' 'avatar registration .' 'avatar title .' 'avatar about .';
+    grid-template-columns: 200px minmax(0, 1fr);
+    grid-template-areas: 'avatar username' 'avatar registration' 'avatar title' 'avatar about';
     align-items: center;
     row-gap: 1rem;
+    min-width: 0;
+    max-width: 100%;
+}
+
+@container user-profile (max-width: 500px) {
+    .profileV2 {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-areas: 'avatar' 'username' 'registration' 'title' 'about';
+    }
 }
 
 @media screen and (max-width: 500px) {
     .profileV2 {
-        grid-template-columns: auto 1fr;
-        grid-template-areas: 'avatar .' 'username .' 'registration .' 'title .' 'about .';
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-areas: 'avatar' 'username' 'registration' 'title' 'about';
     }
 }
 
 .profile__username {
+    container: profile-username / inline-size;
     grid-area: username;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: baseline;
+    column-gap: 0.5ch;
+    min-width: 0;
+    max-width: 100%;
     font-size: 22px;
+}
+
+.profile__username-viewport {
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: thin;
+}
+
+.profile__username-identity {
+    --user-tag-custom-icon-size: 1em;
+
+    font-size: var(--profile-username-fluid-size, 22px);
+    background-size: auto 3em;
+}
+
+.profile__username-identity img {
+    max-width: var(--user-tag-custom-icon-size);
+}
+
+.profile__username-actions {
+    display: inline-flex;
+    align-items: baseline;
+    column-gap: 0.5ch;
+    white-space: nowrap;
+}
+
+@container profile-username (max-width: 760px) {
+    .profile__username-viewport {
+        grid-column: 1 / -1;
+    }
+
+    .profile__username-actions {
+        grid-column: 1;
+        grid-row: 2;
+        margin-block-start: 0.5rem;
+    }
+}
+
+@media screen and (max-width: 500px) {
+    .profile__username-viewport {
+        grid-column: 1 / -1;
+    }
+
+    .profile__username-actions {
+        grid-column: 1;
+        grid-row: 2;
+        margin-block-start: 0.5rem;
+    }
 }
 
 .profile__avatar {
@@ -24,6 +97,13 @@
     border-radius: 10%;
     width: 180px;
     height: 180px;
+}
+
+.profile__registration,
+.profile__title,
+.profile__about {
+    min-width: 0;
+    max-width: 100%;
 }
 
 .profile__registration {
@@ -36,6 +116,7 @@
 
 .profile__about {
     grid-area: about;
+    overflow-wrap: anywhere;
 }
 
 .twoStep__qrCode {

--- a/resources/views/components/user-tag.blade.php
+++ b/resources/views/components/user-tag.blade.php
@@ -28,7 +28,7 @@
                 <i>
                     <img
                         @style([
-                            'max-height: 22px;' =>
+                            'max-height: var(--user-tag-custom-icon-size, 22px);' =>
                                 request()
                                     ->route()
                                     ->getName() === 'users.show',
@@ -81,7 +81,7 @@
             <i>
                 <img
                     @style([
-                        'max-height: 22px;' =>
+                        'max-height: var(--user-tag-custom-icon-size, 22px);' =>
                             request()
                                 ->route()
                                 ->getName() === 'users.show',

--- a/resources/views/user/profile/show.blade.php
+++ b/resources/views/user/profile/show.blade.php
@@ -120,10 +120,32 @@
                     @endif
                 </div>
             </header>
-            <div class="panel__body">
+            <div class="panel__body profile__container">
                 <article class="profileV2">
-                    <x-user-tag :user="$user" :anon="false" class="profile__username">
-                        <x-slot:appendedIcons>
+                    {{-- Reserve width for the username glyphs plus its group, custom, and donor icons. --}}
+                    @php
+                        $profileUsernameWidthUnits = max(mb_strwidth($user->username) * 1.1 + 4.5, 1);
+                        $profileUsernameFluidSize = round(100 / $profileUsernameWidthUnits, 4);
+                    @endphp
+
+                    <div class="profile__username">
+                        <div
+                            class="profile__username-viewport"
+                            style="
+                                --profile-username-fluid-size: clamp(
+                                    8px,
+                                    {{ $profileUsernameFluidSize }}cqi,
+                                    22px
+                                );
+                            "
+                        >
+                            <x-user-tag
+                                :user="$user"
+                                :anon="false"
+                                class="profile__username-identity"
+                            />
+                        </div>
+                        <span class="profile__username-actions">
                             @if ($user->isOnline())
                                 <i
                                     class="{{ config('other.font-awesome') }} fa-circle text-green"
@@ -137,9 +159,12 @@
                             @endif
                             <a
                                 href="{{ route('users.conversations.create', ['user' => auth()->user(), 'username' => $user->username]) }}"
+                                aria-label="{{ __('common.message') }}"
+                                title="{{ __('common.message') }}"
                             >
                                 <i
                                     class="{{ config('other.font-awesome') }} fa-envelope text-info"
+                                    aria-hidden="true"
                                 ></i>
                             </a>
                             @if ($user->warnings()->active()->exists())
@@ -149,8 +174,8 @@
                                     title="{{ __('user.active-warning') }}"
                                 ></i>
                             @endif
-                        </x-slot>
-                    </x-user-tag>
+                        </span>
+                    </div>
                     <time
                         datetime="{{ $user->created_at }}"
                         title="{{ $user->created_at }}"


### PR DESCRIPTION
## Fix Mobile Profile Username Overflow

### Summary

Updated the user profile header to prevent long usernames and their decorative effects from overflowing the mobile viewport.

The solution uses Blade and CSS only; no JavaScript was added or modified.

### Changes

- Kept usernames on a single line without truncation.
- Added responsive font sizing between `8px` and `22px`.
- Used the username’s display width to calculate a suitable CSS container-relative size.
- Scaled group icons, custom icons, donor icons, and background effects with the username.
- Separated status, message, and warning controls so they retain their normal size.
- Moved action controls below the username when horizontal space is limited.
- Updated the profile grid to allow its contents to shrink correctly.
- Added local overflow containment for legacy usernames.
- Added a viewport media-query fallback for browsers without container-query support.

### Result

A decorated, 25-character worst-case username now fits at a `320px` viewport without:

- Wrapping
- Truncation
- Username-area scrolling
- Page-level horizontal overflow

### Validation

Tested at `320px`, `375px`, `500px`, `501px`, `760px`, `867px`, `868px`, `1200px`, and `1600px`.
