### PR TITLE
(Fix) Panel action z-index

### DIFF
--- a/resources/sass/components/_panel.scss
+++ b/resources/sass/components/_panel.scss
@@ -103,6 +103,7 @@
         right: 0;
         top: 0;
         max-width: 90vw;
+        z-index: 1;
 
         &::before {
             content: '\22EE';


### PR DESCRIPTION
It currently looks transparent with table column headers appearing through.